### PR TITLE
nolinebreak patch

### DIFF
--- a/cutecom/qcppdialogimpl.cpp
+++ b/cutecom/qcppdialogimpl.cpp
@@ -18,6 +18,7 @@
 
 #include "qcppdialogimpl.h"
 
+#include <qscrollbar.h>
 #include <qcombobox.h>
 #include <qpushbutton.h>
 #include <qcheckbox.h>
@@ -1362,12 +1363,22 @@ void QCPPDialogImpl::addOutput(const QString& text)
 
 void QCPPDialogImpl::doOutput()
 {
+   QScrollBar* vScrollBar;
+   bool scrollWithText;
+ 
    if (m_outputBuffer.isEmpty())
-   {
-      return;
-   }
-
-   m_outputView->append(m_outputBuffer); 
+     return;
+   
+   vScrollBar = m_outputView->verticalScrollBar();
+   scrollWithText = (vScrollBar->value() == vScrollBar->maximum());
+   
+   QTextCursor cursor(m_outputView->document());
+   cursor.movePosition(QTextCursor::End);
+   cursor.insertText(m_outputBuffer);
+ 
+   if ((scrollWithText))
+     vScrollBar->setValue(vScrollBar->maximum());
+ 
    m_outputBuffer.clear();
 }
 


### PR DESCRIPTION
Hi,

I've found this patch at opensuse 

https://build.opensuse.org/package/view_file/openSUSE:13.2/cutecom/cutecom-0.22.0-nolinebreak.diff?expand=1

According to the changelog, the origin of this patch is Debian.