### PR TITLE
Make cutecom compile and work on Qt5 version less Qt 5.3 - Fix for #8

### DIFF
--- a/controlpanel.cpp
+++ b/controlpanel.cpp
@@ -244,12 +244,21 @@ void ControlPanel::fillDeviceCombo(const QString &deviceName)
     for (auto info : QSerialPortInfo::availablePorts()) {
         m_combo_device->addItem(info.systemLocation());
         if (info.isValid()) {
-            QString deviceInfo = QString("%1 %2\n%3:%4 # %5")
+            QString deviceInfo = QString("%1 %2\n%3:%4 "
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+                                         )
+#else
+                                         "# %5")
+#endif
                                      .arg(info.manufacturer())
                                      .arg(info.description())
                                      .arg(info.vendorIdentifier())
                                      .arg(info.productIdentifier())
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+                    ;
+#else
                                      .arg(info.serialNumber());
+#endif
             m_combo_device->setItemData(numberDevices, deviceInfo, Qt::ToolTipRole);
             QVariant temp = m_combo_device->itemData(numberDevices, Qt::ToolTipRole);
         } else {

--- a/devicecombo.cpp
+++ b/devicecombo.cpp
@@ -38,12 +38,21 @@ void DeviceCombo::refill()
     for (auto info : QSerialPortInfo::availablePorts()) {
         addItem(info.systemLocation());
         if (info.isValid()) {
-            QString deviceInfo = QString("%1 %2\n%3:%4 # %5")
+            QString deviceInfo = QString("%1 %2\n%3:%4 "
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+                                         )
+#else
+                                         "# %5")
+#endif
                                      .arg(info.manufacturer())
                                      .arg(info.description())
                                      .arg(info.vendorIdentifier())
                                      .arg(info.productIdentifier())
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+                    ;
+#else
                                      .arg(info.serialNumber());
+#endif
             setItemData(numberDevices, deviceInfo, Qt::ToolTipRole);
         } else {
             setItemData(numberDevices, tr("Not a valid device"), Qt::ToolTipRole);

--- a/statusbar.cpp
+++ b/statusbar.cpp
@@ -91,12 +91,21 @@ void StatusBar::setToolTip(const QSerialPort *port)
 
     QSerialPortInfo info = QSerialPortInfo(*port);
     if (info.isValid()) {
-        QString deviceInfo = QString("%1 %2\n%3:%4 # %5")
+        QString deviceInfo = QString("%1 %2\n%3:%4 "
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+                                     )
+#else
+                                     "# %5")
+#endif
                                  .arg(info.manufacturer())
                                  .arg(info.description())
                                  .arg(info.vendorIdentifier())
                                  .arg(info.productIdentifier())
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+                ;
+#else
                                  .arg(info.serialNumber());
+#endif
         QWidget::setToolTip(deviceInfo);
     } else {
         QWidget::setToolTip(tr("Not a valid device"));


### PR DESCRIPTION
This will fix issue #8 

    - QSerialPortInfo.serialNumber was introduced in Qt5.3
    - older versions of QtSerialport seem to allow connection parameter changes on already opened devices only
    - Trying to avoid error spamming
    - don't report errors when application is closed and device still open
       device is being closed on MainWindow's deconstructor