### PR TITLE
Added functionality to manually control state of RTS and DTR lines when port has been opened with no flow control or software flow control enabled.

### DIFF
--- a/controlpanel.h
+++ b/controlpanel.h
@@ -80,6 +80,15 @@ private:
     void customBaudRateSet();
     void chooseLogFile();
 
+    /**
+     * @brief   Designed to catch QComboBox::currentIndexChanged(int) signal. Its roles is to set the
+     *          proper visibility of RTS and DTR checkboxes which depends on selected type of flow control.
+     *          If user selects the hardware flow control, then RTS and DTR checkboxes are being invisible.
+     *          If user selects none or software flow control, then RTS and DTR checkboxes are being visible.
+     * @param   index   QComboBox item's index.
+     */
+    void changeVisibilityOfRTSandDTRCheckboxes(int index);
+
 private:
     int m_x;
     int m_y;

--- a/controlpanel.ui
+++ b/controlpanel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>628</width>
-    <height>129</height>
+    <height>130</height>
    </rect>
   </property>
   <property name="autoFillBackground">
@@ -241,6 +241,32 @@
      </item>
      <item>
       <widget class="DeviceCombo" name="m_combo_device" native="true"/>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="m_rts_line">
+       <property name="toolTip">
+        <string>The RTS line is set to logic HIGH when checked. Note that in RS232C the negative logic is used.</string>
+       </property>
+       <property name="locale">
+        <locale language="English" country="UnitedStates"/>
+       </property>
+       <property name="text">
+        <string>RTS</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="m_dtr_line">
+       <property name="toolTip">
+        <string>The DTR line is set to logic HIGH when checked. Note that in RS232C the negative logic is used.</string>
+       </property>
+       <property name="locale">
+        <locale language="English" country="UnitedStates"/>
+       </property>
+       <property name="text">
+        <string>DTR</string>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="horizontalSpacer">

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -81,6 +81,17 @@ protected:
     void sendDone(int exitCode, QProcess::ExitStatus exitStatus);
     void resizeEvent(QResizeEvent *event);
 
+protected slots:
+    /**
+     * @brief Handles QCheckBox::stateChanged signal received from RTS checkbox (placed in control panel).
+     */
+    void setRTSLineState(int checked);
+
+    /**
+     * @brief Handles QCheckBox::stateChanged signal recieved from DTR checkbox (placed in control panel).
+     */
+    void setDTRLineState(int checked);
+
 private:
     void toggleLogging(bool start);
     void fillLineTerminationChooser(const Settings::LineTerminator setting = Settings::LF);


### PR DESCRIPTION
Manually control of RTS/DTR lines are useful in some cases, mostly when dealing with electronics and USB<->UART converters. For example the reset pin of microcontroller can be connected to DTR line and pulling this line to low state for short time will cause a hardware reset of that microcontroller.

Proposed changes and improvements:
- Added two QCheckBoxes to the control panel that are used to manually change state of RTS and DTR lines.
- Implemented visibility setting of these widgets depending on selected type of flow control. When hardware flow control is enabled then they become invisible.
- RTS and DTR checkboxes are enabled only when port is open.
- When serial port is being opened with software flow control enabled, then RTS/DTR are set to logic low (positive voltage on lines, or just 5V/3.3V for TTL converters) as was so far when opening port with no flow control.
