### PR TITLE
Reduce CPU usage of data display.

### DIFF
--- a/datadisplay.cpp
+++ b/datadisplay.cpp
@@ -61,8 +61,7 @@ DataDisplay::DataDisplay(QWidget *parent)
     connect(m_searchPanel, &SearchPanel::findNext, this, &DataDisplay::find);
     connect(m_searchPanel, &SearchPanel::textEntered, m_highlighter, &DataHighlighter::setSearchString);
 
-    connect(&m_timer, SIGNAL(timeout()), this, SLOT(BlockReady()));
-    m_timer.start(100);
+    startTimer(100);
 }
 
 void DataDisplay::clear()
@@ -76,7 +75,7 @@ void DataDisplay::setReadOnly(bool readonly) { m_dataDisplay->setReadOnly(readon
 
 void DataDisplay::setUndoRedoEnabled(bool enable) { m_dataDisplay->setUndoRedoEnabled(enable); }
 
-void DataDisplay::BlockReady(void)
+void DataDisplay::displayDataGo(void)
 {
     if (m_data.isEmpty())
         return;
@@ -194,7 +193,7 @@ void DataDisplay::displayData(const QByteArray &data)
 
     // append the data to end of the parent's TextEdit
     // each part of the line with it's set format
-    // moved to BlockReady()
+    // moved to displayDataGo();
 }
 
 /*!

--- a/datadisplay.h
+++ b/datadisplay.h
@@ -24,6 +24,7 @@
 
 #include <QPlainTextEdit>
 #include <QTime>
+#include <QTimer>
 
 class TimeView;
 class SearchPanel;
@@ -129,6 +130,10 @@ private:
 
     QVector<QTime> *m_timestamps;
     DataHighlighter *m_highlighter;
+    QTimer m_timer;
+
+private slots:
+    void BlockReady(void);
 };
 
 class DataDisplayPrivate : public QPlainTextEdit

--- a/datadisplay.h
+++ b/datadisplay.h
@@ -24,6 +24,7 @@
 
 #include <QPlainTextEdit>
 #include <QTime>
+#include <QTimer>
 
 class TimeView;
 class SearchPanel;
@@ -53,8 +54,6 @@ public:
     void startSearch();
 
     void displayData(const QByteArray &data);
-
-    void displayDataGo(void);
 
     void setDisplayTime(bool displayTime);
 
@@ -132,9 +131,10 @@ private:
     QVector<QTime> *m_timestamps;
     DataHighlighter *m_highlighter;
     bool m_redisplay;
+    QTimer m_bufferingIncomingDataTimer;
 
-protected:
-    void timerEvent(QTimerEvent *event) { displayDataGo(); }
+private slots:
+    void displayDataFromBuffer(void);
 };
 
 class DataDisplayPrivate : public QPlainTextEdit

--- a/datadisplay.h
+++ b/datadisplay.h
@@ -24,7 +24,6 @@
 
 #include <QPlainTextEdit>
 #include <QTime>
-#include <QTimer>
 
 class TimeView;
 class SearchPanel;
@@ -54,6 +53,8 @@ public:
     void startSearch();
 
     void displayData(const QByteArray &data);
+
+    void displayDataGo(void);
 
     void setDisplayTime(bool displayTime);
 
@@ -130,11 +131,10 @@ private:
 
     QVector<QTime> *m_timestamps;
     DataHighlighter *m_highlighter;
-    QTimer m_timer;
     bool m_redisplay;
 
-private slots:
-    void BlockReady(void);
+protected:
+    void timerEvent(QTimerEvent *event) { displayDataGo(); }
 };
 
 class DataDisplayPrivate : public QPlainTextEdit

--- a/datadisplay.h
+++ b/datadisplay.h
@@ -131,6 +131,7 @@ private:
     QVector<QTime> *m_timestamps;
     DataHighlighter *m_highlighter;
     QTimer m_timer;
+    bool m_redisplay;
 
 private slots:
     void BlockReady(void);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -953,9 +953,7 @@ void MainWindow::processData()
     if (m_logFile.isOpen()) {
         m_logFile.write(data);
     }
-    m_output_display->setUpdatesEnabled(false);
     m_output_display->displayData(data);
-    m_output_display->setUpdatesEnabled(true);
 }
 
 void MainWindow::removeSelectedInputItems(bool checked)


### PR DESCRIPTION
Hi.
My sensor is providing many data on 100Hz,
and I see significant CPU usage compared to old CuteCom.
I think the problem is in QPlainTextEdit.
This PR is only a suggestion.
It does batch insertText() operations on timer.
CPU usage is reduced from 40% to 10%.
Dmitry