### PR TITLE
Proposition of popup widget that provides simple way to insert control characters into input field.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Qt5Gui REQUIRED)
 qt5_wrap_ui(uiHeaders controlpanel.ui  mainwindow.ui statusbar.ui sessionmanager.ui searchpanel.ui)
 set(cutecomSrcs main.cpp mainwindow.cpp controlpanel.cpp  devicecombo.cpp
     serialdevicelistmodel.cpp  settings.cpp statusbar.cpp sessionmanager.cpp
-    datadisplay.cpp datahighlighter.cpp searchpanel.cpp timeview.cpp)
+    datadisplay.cpp datahighlighter.cpp searchpanel.cpp timeview.cpp ctrlcharacterspopup.cpp)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 # C++14: set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")

--- a/ctrlcharacterspopup.cpp
+++ b/ctrlcharacterspopup.cpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2017 Slawomir Pabian <sla.pab.dev@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
 #include "ctrlcharacterspopup.h"
 #include <QApplication>
 #include <QKeyEvent>
@@ -342,40 +363,40 @@ void CtrlCharactersPopup::fillCtrlCharsContainer()
 {
     // Append first most common used control characters and their shortcuts
     m_ctrlChars.insert(m_ctrlChars.begin(),
-                {
-                    {0x00, Qt::CTRL + Qt::Key_At, nullptr},
-                    {0x01, Qt::CTRL + Qt::Key_A, nullptr},
-                    {0x02, Qt::CTRL + Qt::Key_B, nullptr},
-                    {0x03, Qt::CTRL + Qt::Key_C, nullptr},
-                    {0x04, Qt::CTRL + Qt::Key_D, nullptr},
-                    {0x05, Qt::CTRL + Qt::Key_E, nullptr},
-                    {0x06, Qt::CTRL + Qt::Key_F, nullptr},
-                    {0x07, Qt::CTRL + Qt::Key_G, nullptr},
-                    {0x08, Qt::CTRL + Qt::Key_H, nullptr},
-                    {0x09, Qt::CTRL + Qt::Key_I, nullptr},
-                    {0x0A, Qt::CTRL + Qt::Key_J, nullptr},
-                    {0x0B, Qt::CTRL + Qt::Key_K, nullptr},
-                    {0x0C, Qt::CTRL + Qt::Key_L, nullptr},
-                    {0x0D, Qt::CTRL + Qt::Key_M, nullptr},
-                    {0x0E, Qt::CTRL + Qt::Key_N, nullptr},
-                    {0x0F, Qt::CTRL + Qt::Key_O, nullptr},
-                    {0x10, Qt::CTRL + Qt::Key_P, nullptr},
-                    {0x11, Qt::CTRL + Qt::Key_Q, nullptr},
-                    {0x12, Qt::CTRL + Qt::Key_R, nullptr},
-                    {0x13, Qt::CTRL + Qt::Key_S, nullptr},
-                    {0x14, Qt::CTRL + Qt::Key_T, nullptr},
-                    {0x15, Qt::CTRL + Qt::Key_U, nullptr},
-                    {0x16, Qt::CTRL + Qt::Key_V, nullptr},
-                    {0x17, Qt::CTRL + Qt::Key_W, nullptr},
-                    {0x18, Qt::CTRL + Qt::Key_X, nullptr},
-                    {0x19, Qt::CTRL + Qt::Key_Y, nullptr},
-                    {0x1A, Qt::CTRL + Qt::Key_Z, nullptr},
-                    {0x1B, Qt::CTRL + Qt::Key_BracketLeft, nullptr},  // Ctrl+[
-                    {0x1C, Qt::CTRL + Qt::Key_Backslash, nullptr},
-                    {0x1D, Qt::CTRL + Qt::Key_BracketRight, nullptr}, // Ctrl+]
-                    {0x1E, Qt::CTRL + Qt::Key_AsciiCircum, nullptr},  // Ctrl+^
-                    {0x1F, Qt::CTRL + Qt::Key_Underscore, nullptr}    // Ctrl+_
-                });
+                       {
+                           std::make_tuple(0x00, Qt::CTRL + Qt::Key_At, nullptr),
+                           std::make_tuple(0x01, Qt::CTRL + Qt::Key_A, nullptr),
+                           std::make_tuple(0x02, Qt::CTRL + Qt::Key_B, nullptr),
+                           std::make_tuple(0x03, Qt::CTRL + Qt::Key_C, nullptr),
+                           std::make_tuple(0x04, Qt::CTRL + Qt::Key_D, nullptr),
+                           std::make_tuple(0x05, Qt::CTRL + Qt::Key_E, nullptr),
+                           std::make_tuple(0x06, Qt::CTRL + Qt::Key_F, nullptr),
+                           std::make_tuple(0x07, Qt::CTRL + Qt::Key_G, nullptr),
+                           std::make_tuple(0x08, Qt::CTRL + Qt::Key_H, nullptr),
+                           std::make_tuple(0x09, Qt::CTRL + Qt::Key_I, nullptr),
+                           std::make_tuple(0x0A, Qt::CTRL + Qt::Key_J, nullptr),
+                           std::make_tuple(0x0B, Qt::CTRL + Qt::Key_K, nullptr),
+                           std::make_tuple(0x0C, Qt::CTRL + Qt::Key_L, nullptr),
+                           std::make_tuple(0x0D, Qt::CTRL + Qt::Key_M, nullptr),
+                           std::make_tuple(0x0E, Qt::CTRL + Qt::Key_N, nullptr),
+                           std::make_tuple(0x0F, Qt::CTRL + Qt::Key_O, nullptr),
+                           std::make_tuple(0x10, Qt::CTRL + Qt::Key_P, nullptr),
+                           std::make_tuple(0x11, Qt::CTRL + Qt::Key_Q, nullptr),
+                           std::make_tuple(0x12, Qt::CTRL + Qt::Key_R, nullptr),
+                           std::make_tuple(0x13, Qt::CTRL + Qt::Key_S, nullptr),
+                           std::make_tuple(0x14, Qt::CTRL + Qt::Key_T, nullptr),
+                           std::make_tuple(0x15, Qt::CTRL + Qt::Key_U, nullptr),
+                           std::make_tuple(0x16, Qt::CTRL + Qt::Key_V, nullptr),
+                           std::make_tuple(0x17, Qt::CTRL + Qt::Key_W, nullptr),
+                           std::make_tuple(0x18, Qt::CTRL + Qt::Key_X, nullptr),
+                           std::make_tuple(0x19, Qt::CTRL + Qt::Key_Y, nullptr),
+                           std::make_tuple(0x1A, Qt::CTRL + Qt::Key_Z, nullptr),
+                           std::make_tuple(0x1B, Qt::CTRL + Qt::Key_BracketLeft, nullptr), // Ctrl+[
+                           std::make_tuple(0x1C, Qt::CTRL + Qt::Key_Backslash, nullptr),
+                           std::make_tuple(0x1D, Qt::CTRL + Qt::Key_BracketRight, nullptr), // Ctrl+]
+                           std::make_tuple(0x1E, Qt::CTRL + Qt::Key_AsciiCircum, nullptr),  // Ctrl+^
+                           std::make_tuple(0x1F, Qt::CTRL + Qt::Key_Underscore, nullptr)    // Ctrl+_
+                       });
 }
 
 void CtrlCharactersPopup::createControlButtons()

--- a/ctrlcharacterspopup.cpp
+++ b/ctrlcharacterspopup.cpp
@@ -1,0 +1,445 @@
+#include "ctrlcharacterspopup.h"
+#include <QApplication>
+#include <QKeyEvent>
+#include <QPainter>
+#include <QPoint>
+#include <QPushButton>
+#include <QSignalMapper>
+#include <QString>
+#include <QTimer>
+#include <algorithm>
+#include <iterator>
+#include <map>
+
+namespace popup_widget
+{
+namespace
+{
+/** Helper struct that prints custom frame on specified widget
+ *
+ */
+struct Frame {
+    explicit Frame(const int size, const int radius)
+        : m_FrameSize(size)
+        , m_radius(radius)
+    {
+        ;
+    }
+
+    ~Frame()
+    {
+        if (true == m_painter.isActive()) {
+            m_painter.end();
+        }
+    }
+
+    void operator()(QWidget *widget)
+    {
+        if (nullptr == widget) {
+            return;
+        }
+
+        auto wWidth = [&]() { return widget->geometry().width(); };
+        auto wHeight = [&]() { return widget->geometry().height(); };
+
+        auto palette = QApplication::palette(widget);
+        // trying to get the same colour as the border of QLineEdit widget. The call to highlight() of QPalette was
+        // found empirically.
+        m_pen.setColor(palette.highlight().color());
+        m_pen.setWidth(m_FrameSize);
+
+        m_painter.begin(widget);
+        m_painter.setRenderHint(QPainter::Antialiasing, true);
+        // set used layout's background
+        m_painter.setBrush(palette.brush(QPalette::Active, QPalette::Base));
+        m_painter.setPen(m_pen);
+
+        if (m_FrameSize > 1) {
+            m_FrameSize /= 2;
+        }
+
+        // start printing from bottom right side after rounded corner
+        m_borderPath.moveTo(wWidth() - m_FrameSize - m_radius, wHeight() - m_FrameSize);
+        //        m_borderPath.lineTo(m_FrameSize + m_radius, wHeight() - m_FrameSize);
+        m_borderPath.moveTo(m_FrameSize /*+ m_radius*/, wHeight() - m_FrameSize);
+        //        printBottomLeftCorner();
+
+        // now print the left edge and left top corner
+        m_borderPath.lineTo(m_FrameSize, m_FrameSize + m_radius);
+        printTopLeftCorner();
+
+        // now print the top edge and right top corner
+        m_borderPath.lineTo(wWidth() - m_FrameSize - m_radius, m_FrameSize);
+        printTopRightCorner();
+
+        // now print the right edge and bottom right corner
+        m_borderPath.lineTo(wWidth() - m_FrameSize, wHeight() - m_FrameSize /*- m_radius*/);
+        //        printBottomRightCorner();
+
+        m_painter.drawPath(m_borderPath);
+        m_painter.end();
+    }
+
+private:
+    qreal &currX() const { return m_borderPath.currentPosition().rx(); }
+
+    qreal &currY() const { return m_borderPath.currentPosition().ry(); }
+
+    // start printing from bottom side
+    void printTopLeftCorner()
+    {
+        c1 = {currX(), currY() - m_radius};
+        c2 = {currX() + m_radius, currY() - m_radius};
+        m_borderPath.cubicTo(c1, c2, c2);
+    }
+
+    // start printing from left side
+    void printTopRightCorner()
+    {
+        c1 = {currX() + m_radius, currY()};
+        c2 = {currX() + m_radius, currY() + m_radius};
+        m_borderPath.cubicTo(c1, c2, c2);
+    }
+
+    // start printing from top side
+    void printBottomRightCorner()
+    {
+        c1 = {currX(), currY() + m_radius};
+        c2 = {currX() - m_radius, currY() + m_radius};
+        m_borderPath.cubicTo(c1, c2, c2);
+    }
+
+    // start printing from right side
+    void printBottomLeftCorner()
+    {
+        c1 = {currX() - m_radius, currY()};
+        c2 = {currX() - m_radius, currY() - m_radius};
+        m_borderPath.cubicTo(c1, c2, c2);
+    }
+
+private:
+    int m_FrameSize;
+    QPen m_pen;
+    QPainter m_painter;
+    QPainterPath m_borderPath;
+    qreal m_radius;
+    QPointF c1;
+    QPointF c2;
+}; // end of struct
+
+} // end of namespace
+
+CtrlCharactersPopup::CtrlCharactersPopup(QLineEdit &parent)
+    : QWidget(&parent)
+    , m_lineEdit(parent)
+    , m_hexMode(false)
+{
+
+    fillCtrlCharsContainer();
+
+    // set size constraints
+    const int minW = ((BUTTONS_IN_ROW + 1) * BUTTON_SIZE) + 100;
+    setFixedWidth(minW);
+    setFixedHeight(BUTTON_SIZE * 4);
+
+    setFocusProxy(&m_lineEdit);
+
+    setWindowFlags(Qt::FramelessWindowHint | Qt::Popup);
+
+    // This widget and layout and childs (widgets) aloso has transparent background, disable border
+    setAttribute(Qt::WA_TranslucentBackground, true);
+    setAttribute(Qt::WA_ShowWithoutActivating, true);
+
+    auto *holder = new QWidget(this);
+    holder->setObjectName("holder");
+    holder->setStyleSheet("QWidget#holder {background:transparent; border:0px solid white;}");
+    holder->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    // Create grid layout to store buttons
+    m_gridLayout = new QGridLayout(this);
+    holder->setLayout(m_gridLayout);
+
+    createControlButtons();
+
+    // Create QScrollArea to store buttons and provide QScrollBar to manage relatively big number of buttons
+    m_scrollArea = new QScrollArea(this);
+    m_scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
+    // Disable border and set transparent background for qscrollarea
+    m_scrollArea->setObjectName("scrollArea");
+    m_scrollArea->setStyleSheet("QScrollArea#scrollArea {background-color:transparent; border: none;}");
+    m_scrollArea->setWidget(holder);
+
+    QSizePolicy sizePolicy{QSizePolicy::Preferred, QSizePolicy::Preferred};
+    sizePolicy.setHorizontalStretch(5);
+    m_scrollArea->setSizePolicy(sizePolicy);
+
+    // Create qlabel to store information about hovered / pressed button
+    m_infoLabel = new QLabel(this);
+    m_infoLabel->setText("");
+    sizePolicy.setHorizontalStretch(0);
+    m_infoLabel->setSizePolicy(sizePolicy);
+
+    // Create horizontal layout to store QScrollArea with buttons and simple labels that
+    // will show some information about hovered button
+    auto *vl = new QHBoxLayout(this);
+    vl->addWidget(m_scrollArea);
+    vl->addWidget(m_infoLabel);
+    this->setLayout(vl);
+
+    m_activatingTimer.setSingleShot(true);
+    connect(&m_activatingTimer, &QTimer::timeout, this,
+            &popup_widget::CtrlCharactersPopup::timedShowTimerExpiredHandler);
+}
+
+void CtrlCharactersPopup::timedShow(const int ms)
+{
+    if (ms > 0) {
+        if (true == m_activatingTimer.isActive()) {
+            m_activatingTimer.stop();
+        }
+        m_activatingTimer.start(ms);
+    }
+}
+
+void CtrlCharactersPopup::timedShowTimerExpiredHandler()
+{
+    // check if Ctrl key is pressed
+    QFlags<Qt::KeyboardModifier> modifiers = QApplication::queryKeyboardModifiers();
+    if (true == modifiers.testFlag(Qt::ControlModifier)) {
+        // show and move window
+        show();
+    }
+}
+
+void CtrlCharactersPopup::buttonClickedSlot(int c)
+{
+    int curPos = m_lineEdit.cursorPosition();
+
+    QString text = m_lineEdit.text();
+
+    bool putAsQchar = true;
+
+    // check if put as hex value or as just UTF-8 QChar
+    if (true == m_hexMode) {
+        do {
+            putAsQchar = false;
+
+            if (0 == curPos) {
+                break;
+            }
+
+            // last occurrence of double quote on the left side
+            int idx = text.lastIndexOf(QChar{'"'}, curPos - 1);
+
+            if (-1 == idx) {
+                break;
+            }
+
+            // last occurrence of double quote on the right side
+            idx = text.indexOf(QChar{'"'}, curPos);
+            if (-1 == idx) {
+                break;
+            }
+
+            // cursor is between double quotes so put as QChar symbol
+            putAsQchar = true;
+        } while (0);
+    }
+
+    if (true == putAsQchar) {
+        m_lineEdit.setText(text.insert(curPos, QChar{0x2400 + c}));
+        // update cursor position inside the widget
+        m_lineEdit.setCursorPosition(curPos + 1);
+    } else {
+        // put as hex value
+        m_lineEdit.setText(text.insert(curPos, QString("%1").arg(c, 2, 16, QChar{'0'})));
+        m_lineEdit.setCursorPosition(curPos + 2);
+    }
+
+    updateInfoLabel(c);
+
+    // scroll to used element
+    auto it = findElementInVector(c);
+    if ((m_ctrlChars.end() != it) && (nullptr != std::get<2>(*it))) {
+        m_scrollArea->ensureWidgetVisible(std::get<2>(*it), 5, 5);
+    }
+}
+
+void CtrlCharactersPopup::buttonFocusInSlot(int c) { updateInfoLabel(c); }
+
+void CtrlCharactersPopup::updateInfoLabel(const int c)
+{
+    // find element in the container
+    auto it = findElementInVector(c);
+
+    QString txt = QString{"Dec: %1\nHex: %2"}.arg(c).arg(c, 2, 16, QChar('0'));
+    // append key sequence, nothing will be printed when QKeySequence(Qt::NoButtons) was assigned
+    if (m_ctrlChars.end() != it) {
+        txt.append(QString("\n%1").arg(std::get<1>(*it).toString()));
+    }
+
+    m_infoLabel->setText(txt);
+}
+
+void CtrlCharactersPopup::paintEvent(QPaintEvent *e)
+{
+    QWidget::paintEvent(e);
+
+    // Paint custom border
+    Frame printFrame{2, 5};
+    printFrame(this);
+}
+
+void CtrlCharactersPopup::keyReleaseEvent(QKeyEvent *event)
+{
+    if (Qt::Key_Control == event->key()) {
+        m_infoLabel->setText("");
+        close();
+    } else {
+        QWidget::keyReleaseEvent(event);
+    }
+}
+
+void CtrlCharactersPopup::show()
+{
+    QWidget::show();
+
+    const QRect lineEditRect = m_lineEdit.geometry();
+    const QPoint lineEditPos = lineEditRect.topLeft();
+    const QRect popupRect = frameGeometry();
+
+    int xPos = lineEditPos.x() + 1;
+    // Don't try to position the popup widget while the width of text field is shorter than popup's width
+    if ((popupRect.width() + 20) <= lineEditRect.width()) {
+        // calculate distance to where the cursor is by measuring the string using font metrics
+        QFontMetrics fm{m_lineEdit.font()};
+
+        // get cursor position at the beginning of qtextedit -> point (coordinates are relative to the qlineedit) was
+        // set empirically, because there is an some margin in qtextedit which value cannot be taken from API, note that
+        // this can lead to position error when this margin will in much different size in other system.
+        const int beginningTextCursPos = m_lineEdit.cursorPositionAt(QPoint{5, lineEditRect.height() / 2});
+        const int currentTextCursPos = m_lineEdit.cursorPosition();
+        QString tempStr = m_lineEdit.displayText().mid(beginningTextCursPos, currentTextCursPos - beginningTextCursPos);
+
+        xPos = lineEditPos.x() + fm.width(tempStr) - (popupRect.width() / 2);
+        if (xPos < lineEditPos.x() + 1) {
+            // align to the left edge of text field
+            xPos = lineEditPos.x() + 1;
+        } else if (xPos > (lineEditPos.x() + m_lineEdit.width() - popupRect.width())) {
+            // align to the right edge of text field
+            xPos = lineEditPos.x() + m_lineEdit.width() - popupRect.width() - 1;
+        }
+    }
+
+    QPoint widgetPos;
+    widgetPos.setX(xPos);
+    // move up but need to overlay some pixels that border of text field should be not visible
+    widgetPos.setY(lineEditPos.y() - popupRect.height() + 4);
+    move(m_lineEdit.parentWidget()->mapToGlobal(widgetPos));
+}
+
+void CtrlCharactersPopup::fillCtrlCharsContainer()
+{
+    // Append first most common used control characters and their shortcuts
+    m_ctrlChars.insert(m_ctrlChars.begin(),
+                {
+                    {0x00, Qt::CTRL + Qt::Key_At, nullptr},
+                    {0x01, Qt::CTRL + Qt::Key_A, nullptr},
+                    {0x02, Qt::CTRL + Qt::Key_B, nullptr},
+                    {0x03, Qt::CTRL + Qt::Key_C, nullptr},
+                    {0x04, Qt::CTRL + Qt::Key_D, nullptr},
+                    {0x05, Qt::CTRL + Qt::Key_E, nullptr},
+                    {0x06, Qt::CTRL + Qt::Key_F, nullptr},
+                    {0x07, Qt::CTRL + Qt::Key_G, nullptr},
+                    {0x08, Qt::CTRL + Qt::Key_H, nullptr},
+                    {0x09, Qt::CTRL + Qt::Key_I, nullptr},
+                    {0x0A, Qt::CTRL + Qt::Key_J, nullptr},
+                    {0x0B, Qt::CTRL + Qt::Key_K, nullptr},
+                    {0x0C, Qt::CTRL + Qt::Key_L, nullptr},
+                    {0x0D, Qt::CTRL + Qt::Key_M, nullptr},
+                    {0x0E, Qt::CTRL + Qt::Key_N, nullptr},
+                    {0x0F, Qt::CTRL + Qt::Key_O, nullptr},
+                    {0x10, Qt::CTRL + Qt::Key_P, nullptr},
+                    {0x11, Qt::CTRL + Qt::Key_Q, nullptr},
+                    {0x12, Qt::CTRL + Qt::Key_R, nullptr},
+                    {0x13, Qt::CTRL + Qt::Key_S, nullptr},
+                    {0x14, Qt::CTRL + Qt::Key_T, nullptr},
+                    {0x15, Qt::CTRL + Qt::Key_U, nullptr},
+                    {0x16, Qt::CTRL + Qt::Key_V, nullptr},
+                    {0x17, Qt::CTRL + Qt::Key_W, nullptr},
+                    {0x18, Qt::CTRL + Qt::Key_X, nullptr},
+                    {0x19, Qt::CTRL + Qt::Key_Y, nullptr},
+                    {0x1A, Qt::CTRL + Qt::Key_Z, nullptr},
+                    {0x1B, Qt::CTRL + Qt::Key_BracketLeft, nullptr},  // Ctrl+[
+                    {0x1C, Qt::CTRL + Qt::Key_Backslash, nullptr},
+                    {0x1D, Qt::CTRL + Qt::Key_BracketRight, nullptr}, // Ctrl+]
+                    {0x1E, Qt::CTRL + Qt::Key_AsciiCircum, nullptr},  // Ctrl+^
+                    {0x1F, Qt::CTRL + Qt::Key_Underscore, nullptr}    // Ctrl+_
+                });
+}
+
+void CtrlCharactersPopup::createControlButtons()
+{
+    // Using custom font for buttons string to make visible utf8 chars
+    QFont btnFont{"Helvetica", 19, QFont::Black};
+    btnFont.setStyleStrategy(QFont::PreferAntialias);
+
+    QSignalMapper *signalMapper = new QSignalMapper(this);
+
+    // add buttons that represent control characters
+    for (std::size_t i = 0; i < m_ctrlChars.size(); ++i) {
+        auto *btn = new custom_ctrl_button::CustomQPushButton{QChar{0x2400 + std::get<0>(m_ctrlChars[i])}, this};
+        btn->setFont(btnFont);
+        btn->setFixedWidth(BUTTON_SIZE);
+        btn->setFixedHeight(BUTTON_SIZE);
+        // set shortcut for button
+        if (std::get<1>(m_ctrlChars[i]) != QKeySequence{Qt::NoButton}) {
+            btn->setShortcut(std::get<1>(m_ctrlChars[i]));
+            // save btn address
+            std::get<2>(m_ctrlChars[i]) = btn;
+        }
+        connect(btn, SIGNAL(clicked()), signalMapper, SLOT(map()));
+        connect(btn, &custom_ctrl_button::CustomQPushButton::focusIn, this, &CtrlCharactersPopup::buttonFocusInSlot);
+        signalMapper->setMapping(btn, std::get<0>(m_ctrlChars[i]));
+        m_gridLayout->addWidget(btn, i / BUTTONS_IN_ROW, i % BUTTONS_IN_ROW, 1, 1);
+    }
+
+    connect(signalMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this,
+            &CtrlCharactersPopup::buttonClickedSlot);
+}
+
+void CtrlCharactersPopup::setHexInsertionMode(bool isHexMode) { m_hexMode = isHexMode; }
+
+CtrlCharactersPopup::VectorConstIterator CtrlCharactersPopup::findElementInVector(const int c)
+{
+    return std::find_if(m_ctrlChars.begin(), m_ctrlChars.end(),
+                        [c](decltype(*m_ctrlChars.end()) &item) -> bool { return c == std::get<0>(item); });
+}
+
+namespace custom_ctrl_button
+{
+CustomQPushButton::CustomQPushButton(QChar c, QWidget *parent)
+    : QPushButton(c, parent)
+    , m_assignedChar(c.unicode() & 0xFF)
+{
+    ;
+}
+
+void CustomQPushButton::focusInEvent(QFocusEvent *event)
+{
+    QPushButton::focusInEvent(event);
+
+    if (true == event->gotFocus()) {
+        emit focusIn(m_assignedChar);
+    }
+}
+
+void CustomQPushButton::enterEvent(QEvent *event)
+{
+    QPushButton::enterEvent(event);
+    emit focusIn(m_assignedChar);
+}
+
+} // end of namespace custom_ctrl_button
+
+} // end of namespace popup_widget

--- a/ctrlcharacterspopup.h
+++ b/ctrlcharacterspopup.h
@@ -1,0 +1,151 @@
+#ifndef CTRLCHARACTERSPOPUP_H
+#define CTRLCHARACTERSPOPUP_H
+
+#include <QGridLayout>
+#include <QKeySequence>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QTimer>
+#include <QWidget>
+#include <map>
+#include <vector>
+
+namespace popup_widget
+{
+
+/**
+ * @brief This class act as popup window glued to the QLineEdit field and displays buttons that represents non-printable
+ * control characters e.g. \n, \t. It has custom layout so opening it looks like it is part of the QLineEdit. User can
+ * select given button by clicking on it or by pressing right shortcut (Ctrl + key) - not all buttons have  * assigned
+ * shortcuts (these will have object: QKeySequence{Qt::NoButton}). After user clicked or used shortcut, then control
+ * character in printable version (UTF-8 with offset 0x2400) is pasted into QLineEdit at current cursor position.
+*/
+class CtrlCharactersPopup : public QWidget
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @param parent QLineEdit widget on which popup window will be glued to and where printable
+     * versions of control characters will be pasted to.
+     */
+    explicit CtrlCharactersPopup(QLineEdit &parent);
+    virtual ~CtrlCharactersPopup() { ; }
+
+    /**
+     *  @brief Calling this method starts one shot timer with interval specified in input parameter then
+     *  when Ctrl key is pressed then popup will show and will be visible until Ctrl key is released.
+     *  @param ms interval in milliseconds for one shot timer.
+     */
+    void timedShow(const int ms);
+
+    /**
+     * @brief If set to true then during insertion of control character into qlineedit will check if cursor position
+     * is between double quotes, if yes then will put there just UTF-8 printable character, if no then will put hex
+     * value of given control character.
+     * @param isHexMode true if current insertion mode is set to hex mode.
+     */
+    void setHexInsertionMode(bool isHexMode);
+
+protected slots:
+
+    /// @brief Called by one shot timer started by timedShow() method.
+    void timedShowTimerExpiredHandler();
+
+    /**
+     * @brief Called when user points mouse cursor on buttons.
+     * @param c value of control character connected to pointed button.
+     */
+    void buttonFocusInSlot(int c);
+
+    /**
+     * @brief Called when user clicks on button or uses shortcut connected with that button.
+     * @param c value of control character connected to clicked button.
+     */
+    void buttonClickedSlot(int c);
+
+protected:
+    using TupleType = std::tuple<int, QKeySequence, QPushButton *>;
+    using VectorConstIterator = std::vector<TupleType>::const_iterator;
+
+    /// @brief Overrides to support custom border.
+    void paintEvent(QPaintEvent *e) override;
+
+    /// @brief Overrides to support closing this widget when user releases Ctrl key
+    void keyReleaseEvent(QKeyEvent *event) override;
+
+    void show();
+
+    /// @brief Creates buttons which represent control characters.
+    void createControlButtons();
+
+    /// @brief Creates container with control characters and assigned shortcuts.
+    void fillCtrlCharsContainer();
+    void updateInfoLabel(const int c);
+    /// @brief Searches container of control characters and returns const iterator to tuple which has the same value as
+    /// input parameter: c at 0 position.
+    VectorConstIterator findElementInVector(const int c);
+
+protected:
+    /// @brief Size of button which represent control character.
+    static constexpr const int BUTTON_SIZE = 30;
+
+    /// @brief Specifies how many buttons in the row will be placed.
+    static constexpr const int BUTTONS_IN_ROW = 5;
+
+    /// @brief QLineEdit widget to which this popup window must be glued to.
+    QLineEdit &m_lineEdit;
+    QGridLayout *m_gridLayout;
+    QScrollArea *m_scrollArea;
+
+    /// @brief Label which will show information about pointed button.
+    QLabel *m_infoLabel;
+    /// @brief This field informs if current insertion mode is set to hex
+    bool m_hexMode;
+
+    /// @brief Container that will hold control character value, assigned shortcut and pointer to CustomQPushButton
+    /// which
+    /// will be used to perform auto-scrolling.
+    std::vector<TupleType> m_ctrlChars;
+    /// @brief One shot timer using to delayed activation (showing) this widget.
+    QTimer m_activatingTimer;
+};
+
+namespace custom_ctrl_button
+{
+
+/// @brief Custom PushButton that overrides focusInEvent and enterEvent.
+class CustomQPushButton : public QPushButton
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @brief Constructs custom button.
+     * @param c assigned control character in printable version (UTF-8 with 0x2400 offset).
+     * @param parent parent widget.
+     */
+    explicit CustomQPushButton(QChar c, QWidget *parent = nullptr);
+    virtual ~CustomQPushButton() { ; }
+
+signals:
+    /// @brief Emitted when user hovers button of if it has been activated by arrow keys.
+    void focusIn(int c);
+
+protected:
+    /// @brief Overrides to emit focusIn() on focusInEvent().
+    void focusInEvent(QFocusEvent *event) override;
+    /// @brief Overrides to emit focusIn() on enterEvent().
+    void enterEvent(QEvent *event) override;
+
+private:
+    /// @brief Stores assigned control character.
+    int m_assignedChar;
+}; // end of CustomQPushButton
+
+} // end of namespace custom_ctrl_button
+
+} // end of namespace popup_widget
+#endif // CTRLCHARACTERSPOPUP_H

--- a/ctrlcharacterspopup.h
+++ b/ctrlcharacterspopup.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2017 Slawomir Pabian <sla.pab.dev@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
 #ifndef CTRLCHARACTERSPOPUP_H
 #define CTRLCHARACTERSPOPUP_H
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,6 +4,7 @@
  *                                                          from https://github.com/preet/cutecom-qt5)
  * Copyright (c) 2015 Meinhard Ritscher <cyc1ingsir@gmail.com>
  * Copyright (c) 2015 Antoine Calando <acalando@free.fr> (improvements added to original CuteCom)
+ * Copyright (c) 2017 Slawomir Pabian <sla.pab.dev@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -58,6 +58,7 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
     , m_sz(nullptr)
     , m_previousChar('\0')
     , m_command_history_model(nullptr)
+    , m_ctrlCharactersPopup(nullptr)
     , m_keyRepeatTimer(this)
     , m_keyCode('\0')
     , m_cmdBufIndex(0)
@@ -106,6 +107,8 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
     m_commandCompleter->setCompletionMode(QCompleter::InlineCompletion);
     m_input_edit->setCompleter(m_commandCompleter);
     updateCommandHistory();
+
+    m_ctrlCharactersPopup = new popup_widget::CtrlCharactersPopup(*m_input_edit);
 
     // adds a custom context menu with a entry to clear whole the command history or just remove selected items
     m_command_history->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -248,6 +251,8 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
                 break;
             }
         } else if (ke->modifiers() == Qt::ControlModifier) {
+            m_ctrlCharactersPopup->timedShow(500);
+
             switch (ke->key()) {
             case Qt::Key_C:
                 // std::cerr<<"c";
@@ -464,11 +469,15 @@ void MainWindow::fillLineTerminationChooser(const Settings::LineTerminator setti
        If the connected device expects CR ('\r') as line termination, it will send CR as line
        termination as well. Setup the DataDisplay to break lines on CR instaed of LF accordingly */
     connect(m_combo_lineterm, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [=]() {
-        if (m_combo_lineterm->currentData().value<Settings::LineTerminator>() == Settings::CR) {
+        auto currentValue = m_combo_lineterm->currentData().value<Settings::LineTerminator>();
+        if (Settings::LineTerminator::CR == currentValue) {
             m_output_display->setLinebreakChar("\r");
         } else {
             m_output_display->setLinebreakChar("\n");
         }
+
+        // inform CtrlCharactersPopup widget about this change
+        m_ctrlCharactersPopup->setHexInsertionMode(Settings::LineTerminator::HEX == currentValue);
     });
 }
 
@@ -642,7 +651,7 @@ bool MainWindow::sendString(const QString &s)
             }
             unsigned int byte;
             if (ascii)
-                byte = (nextByte.toLatin1())[0];
+                byte = nextByte.at(0).unicode() & 0xFF;
             else
                 byte = nextByte.toUInt(0, 16);
 
@@ -652,7 +661,14 @@ bool MainWindow::sendString(const QString &s)
         return true;
     }
 
-    const QByteArray bytes = s.toLatin1();
+    // converts QString into QByteArray, this supports converting control characters being shown in input field as QChars
+    // of Control Pictures from Unicode block.
+    QByteArray bytes;
+    bytes.reserve(s.size());
+    for (auto &c : s) {
+        bytes.append(static_cast<char>(c.unicode()));
+    }
+
     for (int i = 0; i < bytes.length(); i++) {
         if (!sendByte(bytes[i], charDelay))
             return false;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -27,6 +27,7 @@
 #include "sessionmanager.h"
 #include "statusbar.h"
 #include "settings.h"
+#include "ctrlcharacterspopup.h"
 
 #include <QMainWindow>
 #include <QFont>
@@ -83,7 +84,7 @@ protected slots:
     void setRTSLineState(int checked);
 
     /**
-     * @brief Handles QCheckBox::stateChanged signal recieved from DTR checkbox (placed in control panel).
+     * @brief Handles QCheckBox::stateChanged signal received from DTR checkbox (placed in control panel).
      */
     void setDTRLineState(int checked);
 
@@ -112,6 +113,9 @@ private:
     QCompleter *m_commandCompleter;
     QStringListModel *m_command_history_model;
     QMenu *m_command_history_menu;
+
+    /// @brief Popup widget that provides graphical way to enter ASCII control characters into input field.
+    popup_widget::CtrlCharactersPopup *m_ctrlCharactersPopup;
 
     /**
      * @brief m_keyRepeatTimer

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Meinhard Ritscher <cyc1ingsir@gmail.com>
+ * Copyright (c) 2017 Slawomir Pabian <sla.pab.dev@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
According to the discussion in #20 I have implemented a simple widget that contains buttons which represent control characters in range 0x00-0x1F. This widget is constructed to act as popup widget and has custom frame. On hover over buttons on the right side is displaying value of control character in decimal and hex format as well as assigned shortcut.

- This widget is being shown when input field is activated and after 500 ms when user started pressing the Ctrl key. The widget is closed when user releases Ctrl key. 
- User can insert control character into input field by clicking on appropriate button or using shortcut assigned to that button (because the Ctrl key is pressed while widget is visible so user only need to press appropriate key to make pair: Ctrl+KEY).
- Inserting control characters into input field supports hex mode, that is when cursor is between double quotes then QChar with symbol from 'Control Pictures Unicode block' is inserted, otherwise hex value is pasted.
- Widget is positioning according to the width of the input field, length of the text and current cursor position.