### PR TITLE
Fix rpm package build for non-openSUSE based distributions.

### DIFF
--- a/distribution/rpm-generic.spec.in
+++ b/distribution/rpm-generic.spec.in
@@ -9,7 +9,11 @@ Release:        @CPACK_PACKAGE_RELEASE@
 Url:            https://github.com/aneundorf/cutecom
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
+%if %{defined suse_version}
 BuildRequires:  libqt5-qtbase-devel
+%else
+BuildRequires:  qt5-qtbase-devel
+%endif
 Summary:        Serial terminal
 License:        GPL-3.0+
 Group:          Applications/Communications


### PR DESCRIPTION
The change in the spec file checks if the running building system
is OpenSUSE, and if it is, defines libqt5-qtbase-devel as a build requirement,
if it is not, define qt5-qtbase-devel the requirement.

Signed-off-by: Ronaldo Nunez <ronaldo.viera@gmail.com>