### PR TITLE
Increase the maximum custom baudrate value to 9999999

### DIFF
--- a/controlpanel.cpp
+++ b/controlpanel.cpp
@@ -37,7 +37,7 @@ ControlPanel::ControlPanel(QWidget *parent, Settings *settings)
 {
     this->setupUi(this);
 
-    m_baudValidator = new QIntValidator(0, 999000, this);
+    m_baudValidator = new QIntValidator(0, 9999999, this);
     m_combo_Baud->setInsertPolicy(QComboBox::NoInsert);
     const Settings::Session session = settings->getCurrentSession();
 


### PR DESCRIPTION
This allows some common baudrate like 1000000 or 2000000 to be entered by the user and used.
This fixes #50.