### PR TITLE
Support of Qt5>=5.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,12 @@ Makefile*
 *.qmlproject.user
 *.qmlproject.user.*
 
-
+# Build
+CMakeCache.txt
+CMakeFiles/*
+CPackConfig.cmake
+CPackSourceConfig.cmake
+cmake_install.cmake
+cutecom
+cutecom.spec
+cutecom_autogen/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_AUTORCC ON)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Gui REQUIRED)
-#find_package(Serialport REQUIRED)
+find_package(Qt5SerialPort REQUIRED)
 
 qt5_wrap_ui(uiHeaders controlpanel.ui  mainwindow.ui statusbar.ui sessionmanager.ui searchpanel.ui)
 set(cutecomSrcs main.cpp mainwindow.cpp controlpanel.cpp  devicecombo.cpp
@@ -45,7 +45,7 @@ endif(APPLE)
 add_executable(cutecom ${exeType} ${cutecomSrcs} ${uiHeaders} resources.qrc)
 
 
-qt5_use_modules(cutecom Core Gui Widgets SerialPort)
+target_link_libraries(cutecom Qt5::Core Qt5::Gui Qt5::Widgets Qt5::SerialPort)
 
 if (APPLE)
    set_target_properties(cutecom PROPERTIES OUTPUT_NAME CuteCom)

--- a/CREDITS
+++ b/CREDITS
@@ -61,6 +61,9 @@ compress multiple non printable characters
 Dmitry Mastykin
 mix hex and ascii input
 
+Javier Carnero
+https://github.com/emepetres/CuteCom
+Support of Qt5>=5.11
 
 IDEAS - still a ToDo:
 ====================================

--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@
 -line termination was not saved in settings - FIX
 -upgrading to clang-format to version 3.8.0
 -updating travis ci instructions - FIX
+-support for Qt5>=5.11
 0.40.0, January 12, 2017
 -First implementation of searching the output
 -Linked line termination of displayed data 


### PR DESCRIPTION
- CMake compatible with Qt5>=5.11
- Build autogenerated files to gitignore
- Credits & Changelog

Closes #67 