### PR TITLE
Added macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,10 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Gui REQUIRED)
 find_package(Qt5SerialPort REQUIRED)
 
-qt5_wrap_ui(uiHeaders controlpanel.ui  mainwindow.ui statusbar.ui sessionmanager.ui searchpanel.ui)
+qt5_wrap_ui(uiHeaders controlpanel.ui  mainwindow.ui statusbar.ui sessionmanager.ui searchpanel.ui macrosettings.ui)
 set(cutecomSrcs main.cpp mainwindow.cpp controlpanel.cpp  devicecombo.cpp
     serialdevicelistmodel.cpp  settings.cpp statusbar.cpp sessionmanager.cpp
-    datadisplay.cpp datahighlighter.cpp searchpanel.cpp timeview.cpp ctrlcharacterspopup.cpp)
+    datadisplay.cpp datahighlighter.cpp searchpanel.cpp timeview.cpp ctrlcharacterspopup.cpp macrosettings.cpp)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 # C++14: set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")

--- a/CREDITS
+++ b/CREDITS
@@ -65,6 +65,10 @@ Javier Carnero
 https://github.com/emepetres/CuteCom
 Support of Qt5>=5.11
 
+Dimitris Tassopoulos <dimtass@gmail.com>
+https://github.com/dimtass/CuteCom
+Added macros
+
 IDEAS - still a ToDo:
 ====================================
 

--- a/Changelog
+++ b/Changelog
@@ -1,11 +1,11 @@
 0.50.0, tba , 2017
+-added macros support similar to br@y's terminal
 -Enable input of Crl characters using a popup or Ctrl+<x>
 -Windows support added
 -line termination was not saved in settings - FIX
 -upgrading to clang-format to version 3.8.0
 -updating travis ci instructions - FIX
 -support for Qt5>=5.11
--added macros support similar to br@y's terminal
 0.40.0, January 12, 2017
 -First implementation of searching the output
 -Linked line termination of displayed data 

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 0.50.0, tba , 2017
 -added macros support similar to br@y's terminal
+
 0.45.0, June 17 , 2018
 -Enable input of Crl characters using a popup or Ctrl+<x>
 -Windows support added
@@ -7,6 +8,7 @@
 -upgrading to clang-format to version 3.8.0
 -updating travis ci instructions - FIX
 -support for Qt5>=5.11
+
 0.40.0, January 12, 2017
 -First implementation of searching the output
 -Linked line termination of displayed data 

--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@
 -upgrading to clang-format to version 3.8.0
 -updating travis ci instructions - FIX
 -support for Qt5>=5.11
+-added macros support similar to br@y's terminal
 0.40.0, January 12, 2017
 -First implementation of searching the output
 -Linked line termination of displayed data 

--- a/CuteCom.pro
+++ b/CuteCom.pro
@@ -35,7 +35,8 @@ SOURCES += main.cpp\
     datahighlighter.cpp \
     searchpanel.cpp \
     timeview.cpp \
-    ctrlcharacterspopup.cpp
+    ctrlcharacterspopup.cpp \
+    macrosettings.cpp
 
 HEADERS  += mainwindow.h \
     controlpanel.h \
@@ -48,14 +49,16 @@ HEADERS  += mainwindow.h \
     datahighlighter.h \
     searchpanel.h \
     timeview.h \
-    ctrlcharacterspopup.h
+    ctrlcharacterspopup.h \
+    macrosettings.h
 
 
 FORMS    += mainwindow.ui \
     controlpanel.ui \
     statusbar.ui \
     sessionmanager.ui \
-    searchpanel.ui
+    searchpanel.ui \
+    macrosettings.ui
 
 RESOURCES += \
     resources.qrc

--- a/macrosettings.cpp
+++ b/macrosettings.cpp
@@ -26,7 +26,7 @@
 #define MACRO_ITEM(CMD, NAME, TMR_INTERVAL, BUTTON, TMR_ACTIVE, TMR)                                                   \
     new macro_item(CMD, NAME, TMR_INTERVAL, BUTTON, TMR_ACTIVE, TMR)
 
-MacroSettings::MacroSettings(QLineEdit *inputEdit, QPushButton ** mainButtons, QWidget *parent)
+MacroSettings::MacroSettings(QLineEdit *inputEdit, QPushButton **mainButtons, QWidget *parent)
     : QDialog(parent)
     , m_mainForm(parent)
     , m_inputEdit(inputEdit)
@@ -102,7 +102,8 @@ MacroSettings::MacroSettings(QLineEdit *inputEdit, QPushButton ** mainButtons, Q
 
 MacroSettings::~MacroSettings()
 {
-    if (m_macros) delete [] m_macros;
+    if (m_macros)
+        delete[] m_macros;
 }
 
 /**

--- a/macrosettings.cpp
+++ b/macrosettings.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 208 Dimitris Tassopoulos <dimtass@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "macrosettings.h"
+#include <QDebug>
+#include <QMessageBox>
+
+#define MACRO_ITEM(CMD, NAME, TMR_INTERVAL, BUTTON, TMR_ACTIVE, TMR)                                                   \
+    new macro_item(CMD, NAME, TMR_INTERVAL, BUTTON, TMR_ACTIVE, TMR)
+
+MacroSettings::MacroSettings(QLineEdit *inputEdit, QWidget *parent)
+    : QDialog(parent)
+    , m_mainForm(parent)
+    , m_inputEdit(inputEdit)
+{
+    setupUi(this);
+    this->setWindowTitle("Macro Settings");
+    /* Create an array of macro objects in order to make code simpler */
+    m_macros = new macro_item *[NUM_OF_BUTTONS] {
+        MACRO_ITEM(m_le_macro_txt_1, m_le_macro_bt_txt_1, m_sb_macro_tmr_1, m_bt_macro_1, m_cb_enable_macro_tmr_1,
+                   new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_2, m_le_macro_bt_txt_2, m_sb_macro_tmr_2, m_bt_macro_2, m_cb_enable_macro_tmr_2,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_3, m_le_macro_bt_txt_3, m_sb_macro_tmr_3, m_bt_macro_3, m_cb_enable_macro_tmr_3,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_4, m_le_macro_bt_txt_4, m_sb_macro_tmr_4, m_bt_macro_4, m_cb_enable_macro_tmr_4,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_5, m_le_macro_bt_txt_5, m_sb_macro_tmr_5, m_bt_macro_5, m_cb_enable_macro_tmr_5,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_6, m_le_macro_bt_txt_6, m_sb_macro_tmr_6, m_bt_macro_6, m_cb_enable_macro_tmr_6,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_7, m_le_macro_bt_txt_7, m_sb_macro_tmr_7, m_bt_macro_7, m_cb_enable_macro_tmr_7,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_8, m_le_macro_bt_txt_8, m_sb_macro_tmr_8, m_bt_macro_8, m_cb_enable_macro_tmr_8,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_9, m_le_macro_bt_txt_9, m_sb_macro_tmr_9, m_bt_macro_9, m_cb_enable_macro_tmr_9,
+                       new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_10, m_le_macro_bt_txt_10, m_sb_macro_tmr_10, m_bt_macro_10,
+                       m_cb_enable_macro_tmr_10, new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_11, m_le_macro_bt_txt_11, m_sb_macro_tmr_11, m_bt_macro_11,
+                       m_cb_enable_macro_tmr_11, new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_12, m_le_macro_bt_txt_12, m_sb_macro_tmr_12, m_bt_macro_12,
+                       m_cb_enable_macro_tmr_12, new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_13, m_le_macro_bt_txt_13, m_sb_macro_tmr_13, m_bt_macro_13,
+                       m_cb_enable_macro_tmr_13, new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_14, m_le_macro_bt_txt_14, m_sb_macro_tmr_14, m_bt_macro_14,
+                       m_cb_enable_macro_tmr_14, new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_15, m_le_macro_bt_txt_15, m_sb_macro_tmr_15, m_bt_macro_15,
+                       m_cb_enable_macro_tmr_15, new QTimer(this)),
+            MACRO_ITEM(m_le_macro_txt_16, m_le_macro_bt_txt_16, m_sb_macro_tmr_16, m_bt_macro_16,
+                       m_cb_enable_macro_tmr_16, new QTimer(this)),
+    };
+
+    /* Setup signal/slots */
+    for (size_t i = 0; i < NUM_OF_BUTTONS; i++) {
+        connect(m_macros[i]->button, &QPushButton::clicked, this, &MacroSettings::macroPress);
+        connect(m_macros[i]->name, &QLineEdit::textChanged, this,
+                [=]() { m_macros[i]->button->setText(m_macros[i]->name->text()); });
+        connect(m_macros[i]->tmr_active, &QCheckBox::stateChanged, [=](int state) {
+            if (state == Qt::Checked) {
+                m_macros[i]->tmr->stop();
+                m_macros[i]->tmr->setInterval(m_macros[i]->tmr_interval->text().toInt());
+                m_macros[i]->tmr->start();
+                qDebug() << "Timer " << i << " started.";
+            } else {
+                m_macros[i]->tmr->stop();
+                qDebug() << "Timer " << i << " stopped.";
+            }
+        });
+        connect(m_macros[i]->tmr, &QTimer::timeout, [=]() {
+            m_inputEdit->setText(m_macros[i]->cmd->text());
+            emit sendCmd();
+        });
+    }
+    connect(m_bt_load_macros, &QPushButton::clicked, this, &MacroSettings::openFile);
+    connect(m_bt_save_macros, &QPushButton::clicked, this, &MacroSettings::saveFile);
+
+    m_lbl_macros_path->setText("");
+}
+
+/**
+ * @brief Extract the button index. That's a bit dirty way to get indexes
+ * from the buttons. For this to happen the buttons must always be named
+ * as 'm_bt_macro_' and then the index.
+ * @param btnName The button object name
+ * @return int The index of the button that corresponds to m_macros[]
+ */
+int MacroSettings::getButtonIndex(QString btnName)
+{
+    int idx = -1;
+
+    if (btnName.startsWith("m_bt_macro_")) {
+        idx = btnName.remove("m_bt_macro_").toInt() - 1;
+    }
+    return idx;
+}
+
+/**
+ * @brief Sends the cmd that corresponds to the macro button
+ */
+void MacroSettings::macroPress()
+{
+    QPushButton *button = qobject_cast<QPushButton *>(sender());
+    if (button) {
+        int idx = getButtonIndex(button->objectName());
+        if (idx < 0)
+            return;
+
+        qDebug() << "Sender: " << m_macros[idx]->button->objectName();
+        /* Get macro text */
+        QString cmd = m_macros[idx]->cmd->text();
+        m_inputEdit->setText(cmd);
+        emit sendCmd();
+    }
+}
+
+/**
+ * @brief Load a macro file that is compatible with Br@y's terminal
+ * @param fname The filename of the *.tmf file.
+ */
+void MacroSettings::loadFile(QString fname)
+{
+    if (fname.isEmpty())
+        return;
+
+    QFile file(fname);
+
+    if (!file.open(QFile::ReadOnly | QFile::Text)) {
+        QMessageBox::warning(this, "Could not open file", file.errorString());
+        return;
+    }
+    QTextStream in(&file);
+    if (parseFile(in))
+        m_lbl_macros_path->setText(fname);
+
+    file.close();
+    if (QString::compare(m_macroFilename, fname, Qt::CaseSensitive)) {
+        m_macroFilename = fname;
+        m_lbl_macros_path->setText(m_macroFilename);
+        emit fileChanged(m_macroFilename);
+    }
+}
+
+void MacroSettings::openFile()
+{
+    QString fname = QFileDialog::getOpenFileName(this, "Open a bray's terminal macro settings file", QDir::homePath(),
+                                                 "Macros (*.tmf)");
+    if (!fname.isEmpty())
+        loadFile(fname);
+}
+
+/**
+ * @brief Parse a macro *.tmf file and fill the dialog form
+ * @param in The file text stream
+ * @return true if all gone OK, otherwise false
+ */
+bool MacroSettings::parseFile(QTextStream &in)
+{
+    /* Read the first line */
+    QString line = in.readLine();
+    if (line.startsWith("# Terminal macro file v2")) {
+        for (size_t i = 0; i < NUM_OF_BUTTONS; i++) {
+            /* Get button name */
+            line = in.readLine();
+            m_macros[i]->button->setText(line);
+            m_macros[i]->name->setText(line);
+            /* Get button cmd */
+            line = in.readLine();
+            m_macros[i]->cmd->setText(line);
+        }
+    } else {
+        QMessageBox::warning(this, "Error", "Unsupported macro file!");
+        return false;
+    }
+    return true;
+}
+
+void MacroSettings::saveFile()
+{
+    QDir dir(QDir::homePath());
+    QString fname = QFileDialog::getSaveFileName(this, "Open a bray's terminal macro settings file",
+                                                 dir.filePath(m_macroFilename), "Macros (*.tmf)");
+    if (fname.isEmpty())
+        return;
+
+    qDebug() << "Save to: " << fname;
+    QFile file(fname);
+    if (!file.open(QFile::WriteOnly | QFile::Text)) {
+        QMessageBox::warning(this, "Could not open file", file.errorString());
+        return;
+    }
+    QTextStream out(&file);
+    out << "# Terminal macro file v2" << endl;
+    for (size_t i = 0; i < NUM_OF_BUTTONS; i++) {
+        out << m_macros[i]->button->text() << endl;
+        out << m_macros[i]->cmd->text() << endl;
+    }
+    out.flush();
+    file.close();
+    if (QString::compare(m_macroFilename, fname, Qt::CaseSensitive)) {
+        m_macroFilename = fname;
+        m_lbl_macros_path->setText(m_macroFilename);
+        emit fileChanged(m_macroFilename);
+    }
+}

--- a/macrosettings.cpp
+++ b/macrosettings.cpp
@@ -26,7 +26,7 @@
 #define MACRO_ITEM(CMD, NAME, TMR_INTERVAL, BUTTON, TMR_ACTIVE, TMR)                                                   \
     new macro_item(CMD, NAME, TMR_INTERVAL, BUTTON, TMR_ACTIVE, TMR)
 
-MacroSettings::MacroSettings(QLineEdit *inputEdit, QWidget *parent)
+MacroSettings::MacroSettings(QLineEdit *inputEdit, QPushButton ** mainButtons, QWidget *parent)
     : QDialog(parent)
     , m_mainForm(parent)
     , m_inputEdit(inputEdit)
@@ -71,6 +71,10 @@ MacroSettings::MacroSettings(QLineEdit *inputEdit, QWidget *parent)
 
     /* Setup signal/slots */
     for (size_t i = 0; i < NUM_OF_BUTTONS; i++) {
+        connect(mainButtons[i], SIGNAL(clicked(bool)), this, SLOT(macroPress()));
+        connect(m_macros[i]->name, &QLineEdit::textChanged, this,
+                [=]() { mainButtons[i]->setText(m_macros[i]->name->text()); });
+
         connect(m_macros[i]->button, &QPushButton::clicked, this, &MacroSettings::macroPress);
         connect(m_macros[i]->name, &QLineEdit::textChanged, this,
                 [=]() { m_macros[i]->button->setText(m_macros[i]->name->text()); });
@@ -94,6 +98,11 @@ MacroSettings::MacroSettings(QLineEdit *inputEdit, QWidget *parent)
     connect(m_bt_save_macros, &QPushButton::clicked, this, &MacroSettings::saveFile);
 
     m_lbl_macros_path->setText("");
+}
+
+MacroSettings::~MacroSettings()
+{
+    if (m_macros) delete [] m_macros;
 }
 
 /**

--- a/macrosettings.cpp
+++ b/macrosettings.cpp
@@ -235,22 +235,20 @@ void MacroSettings::saveFile()
 
 void MacroSettings::helpMsg(void)
 {
-    QString help_str =
-        "In order to use macros you need to need to\n"
-        "fill the serial command you want to send in\n"
-        "the first column. Then you can name the macro\n"
-        "in the second column. This name will also be\n"
-        "applied on the button label.\n\n"
-        "To trigger the macro you can press the button\n"
-        "on this dialog or in the main interface.\n\n"
-        "If you want to auto-trigger the macro on time\n"
-        "intervals then you can set the (msec) timer\n"
-        "interval and then enable/disable the macro timer\n"
-        "using the checkbox. Note that each timer is\n"
-        "autonomous.\n\n"
-        "The macro format is compatible with the tmf\n"
-        "format of Bray's terminal."
-        ;
+    QString help_str = "In order to use macros you need to need to\n"
+                       "fill the serial command you want to send in\n"
+                       "the first column. Then you can name the macro\n"
+                       "in the second column. This name will also be\n"
+                       "applied on the button label.\n\n"
+                       "To trigger the macro you can press the button\n"
+                       "on this dialog or in the main interface.\n\n"
+                       "If you want to auto-trigger the macro on time\n"
+                       "intervals then you can set the (msec) timer\n"
+                       "interval and then enable/disable the macro timer\n"
+                       "using the checkbox. Note that each timer is\n"
+                       "autonomous.\n\n"
+                       "The macro format is compatible with the tmf\n"
+                       "format of Bray's terminal.";
 
     QMessageBox::information(this, "How to use", help_str);
 }

--- a/macrosettings.cpp
+++ b/macrosettings.cpp
@@ -96,6 +96,7 @@ MacroSettings::MacroSettings(QLineEdit *inputEdit, QPushButton **mainButtons, QW
     }
     connect(m_bt_load_macros, &QPushButton::clicked, this, &MacroSettings::openFile);
     connect(m_bt_save_macros, &QPushButton::clicked, this, &MacroSettings::saveFile);
+    connect(m_bt_macro_help, &QPushButton::clicked, this, &MacroSettings::helpMsg);
 
     m_lbl_macros_path->setText("");
 }
@@ -230,4 +231,26 @@ void MacroSettings::saveFile()
         m_lbl_macros_path->setText(m_macroFilename);
         emit fileChanged(m_macroFilename);
     }
+}
+
+void MacroSettings::helpMsg(void)
+{
+    QString help_str =
+        "In order to use macros you need to need to\n"
+        "fill the serial command you want to send in\n"
+        "the first column. Then you can name the macro\n"
+        "in the second column. This name will also be\n"
+        "applied on the button label.\n\n"
+        "To trigger the macro you can press the button\n"
+        "on this dialog or in the main interface.\n\n"
+        "If you want to auto-trigger the macro on time\n"
+        "intervals then you can set the (msec) timer\n"
+        "interval and then enable/disable the macro timer\n"
+        "using the checkbox. Note that each timer is\n"
+        "autonomous.\n\n"
+        "The macro format is compatible with the tmf\n"
+        "format of Bray's terminal."
+        ;
+
+    QMessageBox::information(this, "How to use", help_str);
 }

--- a/macrosettings.h
+++ b/macrosettings.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 208 Dimitris Tassopoulos <dimtass@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef MACROSETTINGS_H
+#define MACROSETTINGS_H
+
+#include "ui_macrosettings.h"
+#include <QFileDialog>
+#include <QTimer>
+
+class MacroSettings : public QDialog, private Ui::MacroSettings
+{
+    Q_OBJECT
+
+    enum { NUM_OF_BUTTONS = 16 };
+
+public:
+    explicit MacroSettings(QLineEdit *inputEdit, QWidget *parent = 0);
+    void showPanel(bool setVisible);
+    QString getMacroFilename(void) { return m_macroFilename; }
+    void loadFile(QString fname);
+
+public slots:
+    void macroPress();
+
+protected slots:
+    void openFile();
+    void saveFile();
+
+signals:
+    void closing();
+    void sendCmd();
+    void fileChanged(QString);
+
+private:
+    struct macro_item {
+        macro_item() = default;
+        macro_item(QLineEdit *cmd, QLineEdit *name, QSpinBox *tmr_interval, QPushButton *button, QCheckBox *tmr_active,
+                   QTimer *tmr)
+            : cmd(cmd)
+            , name(name)
+            , tmr_interval(tmr_interval)
+            , button(button)
+            , tmr_active(tmr_active)
+            , tmr(tmr)
+        {
+        }
+        QLineEdit *cmd;
+        QLineEdit *name;
+        QSpinBox *tmr_interval;
+        QPushButton *button;
+        QCheckBox *tmr_active;
+        QTimer *tmr;
+    };
+    int getButtonIndex(QString btnName);
+    bool parseFile(QTextStream &in);
+    QWidget *m_mainForm;
+    QLineEdit *m_inputEdit;
+    QString m_macroFilename;
+    struct macro_item **m_macros;
+};
+
+#endif // MACROSETTINGS_H

--- a/macrosettings.h
+++ b/macrosettings.h
@@ -76,6 +76,7 @@ private:
     QLineEdit *m_inputEdit;
     QString m_macroFilename;
     struct macro_item **m_macros;
+    void helpMsg(void);
 };
 
 #endif // MACROSETTINGS_H

--- a/macrosettings.h
+++ b/macrosettings.h
@@ -30,10 +30,9 @@ class MacroSettings : public QDialog, private Ui::MacroSettings
 {
     Q_OBJECT
 
-
 public:
     enum { NUM_OF_BUTTONS = 16 };
-    explicit MacroSettings(QLineEdit *inputEdit, QPushButton ** mainButtons, QWidget *parent = 0);
+    explicit MacroSettings(QLineEdit *inputEdit, QPushButton **mainButtons, QWidget *parent = 0);
     virtual ~MacroSettings();
     void showPanel(bool setVisible);
     QString getMacroFilename(void) { return m_macroFilename; }

--- a/macrosettings.h
+++ b/macrosettings.h
@@ -30,10 +30,11 @@ class MacroSettings : public QDialog, private Ui::MacroSettings
 {
     Q_OBJECT
 
-    enum { NUM_OF_BUTTONS = 16 };
 
 public:
-    explicit MacroSettings(QLineEdit *inputEdit, QWidget *parent = 0);
+    enum { NUM_OF_BUTTONS = 16 };
+    explicit MacroSettings(QLineEdit *inputEdit, QPushButton ** mainButtons, QWidget *parent = 0);
+    virtual ~MacroSettings();
     void showPanel(bool setVisible);
     QString getMacroFilename(void) { return m_macroFilename; }
     void loadFile(QString fname);

--- a/macrosettings.ui
+++ b/macrosettings.ui
@@ -6,15 +6,33 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>546</width>
-    <height>578</height>
+    <width>542</width>
+    <height>600</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>542</width>
+    <height>600</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>542</width>
+    <height>600</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
   <property name="sizeGripEnabled">
-   <bool>true</bool>
+   <bool>false</bool>
   </property>
   <widget class="QGroupBox" name="groupBox">
    <property name="geometry">
@@ -37,6 +55,9 @@
       <height>25</height>
      </rect>
     </property>
+    <property name="toolTip">
+     <string extracomment="Load a macro file">Load a macro settings file (tmf)</string>
+    </property>
     <property name="text">
      <string>Load</string>
     </property>
@@ -50,6 +71,9 @@
       <height>25</height>
      </rect>
     </property>
+    <property name="toolTip">
+     <string extracomment="Save to a macro file">Save macros to file</string>
+    </property>
     <property name="text">
      <string>Save</string>
     </property>
@@ -57,14 +81,30 @@
    <widget class="QLabel" name="m_lbl_macros_path">
     <property name="geometry">
      <rect>
-      <x>170</x>
+      <x>200</x>
       <y>35</y>
-      <width>351</width>
-      <height>17</height>
+      <width>321</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
      <string>TextLabel</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_help">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>30</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="toolTip">
+     <string>Help</string>
+    </property>
+    <property name="text">
+     <string>?</string>
     </property>
    </widget>
   </widget>
@@ -74,7 +114,7 @@
      <x>5</x>
      <y>60</y>
      <width>531</width>
-     <height>511</height>
+     <height>531</height>
     </rect>
    </property>
    <property name="title">
@@ -83,21 +123,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_1">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>30</y>
+      <x>5</x>
+      <y>50</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QLineEdit" name="m_le_macro_bt_txt_1">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>30</y>
+      <x>285</x>
+      <y>50</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -106,8 +152,8 @@
    <widget class="QPushButton" name="m_bt_macro_1">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>30</y>
+      <x>355</x>
+      <y>50</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -119,11 +165,14 @@
    <widget class="QSpinBox" name="m_sb_macro_tmr_1">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>30</y>
+      <x>430</x>
+      <y>50</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -135,11 +184,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_1">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>30</y>
+      <x>505</x>
+      <y>50</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -148,11 +200,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_2">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>60</y>
+      <x>285</x>
+      <y>80</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -161,21 +216,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_2">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>60</y>
+      <x>5</x>
+      <y>80</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_2">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>60</y>
+      <x>430</x>
+      <y>80</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -187,8 +248,8 @@
    <widget class="QPushButton" name="m_bt_macro_2">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>60</y>
+      <x>355</x>
+      <y>80</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -200,11 +261,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_2">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>60</y>
+      <x>505</x>
+      <y>80</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -213,11 +277,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_3">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>90</y>
+      <x>285</x>
+      <y>110</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -226,21 +293,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_3">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>90</y>
+      <x>5</x>
+      <y>110</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_3">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>90</y>
+      <x>430</x>
+      <y>110</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -252,8 +325,8 @@
    <widget class="QPushButton" name="m_bt_macro_3">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>90</y>
+      <x>355</x>
+      <y>110</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -265,11 +338,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_3">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>90</y>
+      <x>505</x>
+      <y>110</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -278,11 +354,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_4">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>120</y>
+      <x>285</x>
+      <y>140</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -291,21 +370,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_4">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>120</y>
+      <x>5</x>
+      <y>140</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_4">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>120</y>
+      <x>430</x>
+      <y>140</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -317,8 +402,8 @@
    <widget class="QPushButton" name="m_bt_macro_4">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>120</y>
+      <x>355</x>
+      <y>140</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -330,11 +415,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_4">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>120</y>
+      <x>505</x>
+      <y>140</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -343,11 +431,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_5">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>150</y>
+      <x>285</x>
+      <y>170</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -356,21 +447,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_5">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>150</y>
+      <x>5</x>
+      <y>170</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_5">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>150</y>
+      <x>430</x>
+      <y>170</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -382,8 +479,8 @@
    <widget class="QPushButton" name="m_bt_macro_5">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>150</y>
+      <x>355</x>
+      <y>170</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -395,11 +492,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_5">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>150</y>
+      <x>505</x>
+      <y>170</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -408,11 +508,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_6">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>180</y>
+      <x>285</x>
+      <y>200</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -421,21 +524,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_6">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>180</y>
+      <x>5</x>
+      <y>200</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_6">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>180</y>
+      <x>430</x>
+      <y>200</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -447,8 +556,8 @@
    <widget class="QPushButton" name="m_bt_macro_6">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>180</y>
+      <x>355</x>
+      <y>200</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -460,11 +569,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_6">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>180</y>
+      <x>505</x>
+      <y>200</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -473,11 +585,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_7">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>210</y>
+      <x>285</x>
+      <y>230</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -486,21 +601,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_7">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>210</y>
+      <x>5</x>
+      <y>230</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_7">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>210</y>
+      <x>430</x>
+      <y>230</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -512,8 +633,8 @@
    <widget class="QPushButton" name="m_bt_macro_7">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>210</y>
+      <x>355</x>
+      <y>230</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -525,11 +646,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_7">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>210</y>
+      <x>505</x>
+      <y>230</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -538,11 +662,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_8">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>240</y>
+      <x>285</x>
+      <y>260</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -551,21 +678,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_8">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>240</y>
+      <x>5</x>
+      <y>260</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_8">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>240</y>
+      <x>430</x>
+      <y>260</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -577,8 +710,8 @@
    <widget class="QPushButton" name="m_bt_macro_8">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>240</y>
+      <x>355</x>
+      <y>260</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -590,11 +723,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_8">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>240</y>
+      <x>505</x>
+      <y>260</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -603,11 +739,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_9">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>270</y>
+      <x>285</x>
+      <y>290</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -616,21 +755,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_9">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>270</y>
+      <x>5</x>
+      <y>290</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_9">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>270</y>
+      <x>430</x>
+      <y>290</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -642,8 +787,8 @@
    <widget class="QPushButton" name="m_bt_macro_9">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>270</y>
+      <x>355</x>
+      <y>290</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -655,11 +800,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_9">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>270</y>
+      <x>505</x>
+      <y>290</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -668,11 +816,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_10">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>300</y>
+      <x>285</x>
+      <y>320</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -681,21 +832,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_10">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>300</y>
+      <x>5</x>
+      <y>320</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_10">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>300</y>
+      <x>430</x>
+      <y>320</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -707,8 +864,8 @@
    <widget class="QPushButton" name="m_bt_macro_10">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>300</y>
+      <x>355</x>
+      <y>320</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -720,11 +877,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_10">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>300</y>
+      <x>505</x>
+      <y>320</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -733,11 +893,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_11">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>330</y>
+      <x>285</x>
+      <y>350</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -746,21 +909,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_11">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>330</y>
+      <x>5</x>
+      <y>350</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_11">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>330</y>
+      <x>430</x>
+      <y>350</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -772,8 +941,8 @@
    <widget class="QPushButton" name="m_bt_macro_11">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>330</y>
+      <x>355</x>
+      <y>350</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -785,11 +954,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_11">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>330</y>
+      <x>505</x>
+      <y>350</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -798,11 +970,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_12">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>360</y>
+      <x>285</x>
+      <y>380</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -811,21 +986,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_12">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>360</y>
+      <x>5</x>
+      <y>380</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_12">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>360</y>
+      <x>430</x>
+      <y>380</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -837,8 +1018,8 @@
    <widget class="QPushButton" name="m_bt_macro_12">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>360</y>
+      <x>355</x>
+      <y>380</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -850,11 +1031,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_12">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>360</y>
+      <x>505</x>
+      <y>380</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -863,11 +1047,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_13">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>390</y>
+      <x>285</x>
+      <y>410</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -876,21 +1063,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_13">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>390</y>
+      <x>5</x>
+      <y>410</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_13">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>390</y>
+      <x>430</x>
+      <y>410</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -902,8 +1095,8 @@
    <widget class="QPushButton" name="m_bt_macro_13">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>390</y>
+      <x>355</x>
+      <y>410</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -915,11 +1108,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_13">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>390</y>
+      <x>505</x>
+      <y>410</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -928,11 +1124,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_14">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>420</y>
+      <x>285</x>
+      <y>440</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -941,21 +1140,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_14">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>420</y>
+      <x>5</x>
+      <y>440</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_14">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>420</y>
+      <x>430</x>
+      <y>440</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -967,8 +1172,8 @@
    <widget class="QPushButton" name="m_bt_macro_14">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>420</y>
+      <x>355</x>
+      <y>440</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -980,11 +1185,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_14">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>420</y>
+      <x>505</x>
+      <y>440</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -993,11 +1201,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_15">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>450</y>
+      <x>285</x>
+      <y>470</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -1006,21 +1217,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_15">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>450</y>
+      <x>5</x>
+      <y>470</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_15">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>450</y>
+      <x>430</x>
+      <y>470</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -1032,8 +1249,8 @@
    <widget class="QPushButton" name="m_bt_macro_15">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>450</y>
+      <x>355</x>
+      <y>470</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -1045,11 +1262,14 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_15">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>450</y>
+      <x>505</x>
+      <y>470</y>
       <width>21</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
     </property>
     <property name="text">
      <string/>
@@ -1058,11 +1278,14 @@
    <widget class="QLineEdit" name="m_le_macro_bt_txt_16">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>480</y>
+      <x>285</x>
+      <y>500</y>
       <width>65</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Macro name</string>
     </property>
     <property name="text">
      <string/>
@@ -1071,21 +1294,27 @@
    <widget class="QLineEdit" name="m_le_macro_txt_16">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>480</y>
+      <x>5</x>
+      <y>500</y>
       <width>275</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Serial command to send when macro is triggered.</string>
     </property>
    </widget>
    <widget class="QSpinBox" name="m_sb_macro_tmr_16">
     <property name="geometry">
      <rect>
-      <x>435</x>
-      <y>480</y>
+      <x>430</x>
+      <y>500</y>
       <width>70</width>
       <height>25</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Timer interval (ms)</string>
     </property>
     <property name="maximum">
      <number>300000</number>
@@ -1097,8 +1326,8 @@
    <widget class="QPushButton" name="m_bt_macro_16">
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>480</y>
+      <x>355</x>
+      <y>500</y>
       <width>70</width>
       <height>25</height>
      </rect>
@@ -1110,14 +1339,85 @@
    <widget class="QCheckBox" name="m_cb_enable_macro_tmr_16">
     <property name="geometry">
      <rect>
-      <x>510</x>
-      <y>480</y>
+      <x>505</x>
+      <y>500</y>
       <width>21</width>
       <height>25</height>
      </rect>
     </property>
+    <property name="toolTip">
+     <string>Enable timer</string>
+    </property>
     <property name="text">
      <string/>
+    </property>
+   </widget>
+   <widget class="QLabel" name="m_lbl_macro_serial_command">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>25</y>
+      <width>261</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Serial command</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="m_lbl_macro_name">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>25</y>
+      <width>61</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="mouseTracking">
+     <bool>true</bool>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Name&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="m_lbl_macro_trigger">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>25</y>
+      <width>67</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Trigger&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="m_lbl_macro_interval">
+    <property name="geometry">
+     <rect>
+      <x>440</x>
+      <y>25</y>
+      <width>51</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>(msec)</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="m_lbl_macro_tmr">
+    <property name="geometry">
+     <rect>
+      <x>500</x>
+      <y>25</y>
+      <width>67</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Tmr</string>
     </property>
    </widget>
   </widget>

--- a/macrosettings.ui
+++ b/macrosettings.ui
@@ -1,0 +1,1127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MacroSettings</class>
+ <widget class="QDialog" name="MacroSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>546</width>
+    <height>578</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>5</x>
+     <y>0</y>
+     <width>531</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Manage Macros</string>
+   </property>
+   <widget class="QPushButton" name="m_bt_load_macros">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Load</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_save_macros">
+    <property name="geometry">
+     <rect>
+      <x>90</x>
+      <y>30</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Save</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="m_lbl_macros_path">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>35</y>
+      <width>351</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>TextLabel</string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_2">
+   <property name="geometry">
+    <rect>
+     <x>5</x>
+     <y>60</y>
+     <width>531</width>
+     <height>511</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Transmit Macros</string>
+   </property>
+   <widget class="QLineEdit" name="m_le_macro_txt_1">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_1">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>30</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_1">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>30</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M1</string>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_1">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>30</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_1">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>30</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_2">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>60</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>60</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_2">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>60</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_2">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>60</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M2</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_2">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>60</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_3">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>90</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_3">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>90</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_3">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>90</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_3">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>90</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M3</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_3">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>90</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_4">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>120</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_4">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>120</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_4">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>120</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_4">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>120</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M4</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_4">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>120</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_5">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>150</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_5">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>150</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_5">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>150</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_5">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>150</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M5</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_5">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>150</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_6">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>180</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_6">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>180</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_6">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>180</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_6">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>180</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M6</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_6">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>180</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_7">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>210</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_7">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>210</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_7">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>210</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_7">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>210</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M7</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_7">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>210</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_8">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>240</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_8">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>240</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_8">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>240</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_8">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>240</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M8</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_8">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>240</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_9">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>270</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_9">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>270</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_9">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>270</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_9">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>270</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M9</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_9">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>270</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_10">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>300</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_10">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>300</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_10">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>300</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_10">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>300</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M10</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_10">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>300</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_11">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>330</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_11">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>330</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_11">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>330</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_11">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>330</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M11</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_11">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>330</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_12">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>360</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_12">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>360</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_12">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>360</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_12">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>360</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M12</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_12">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>360</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_13">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>390</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_13">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>390</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_13">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>390</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_13">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>390</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M13</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_13">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>390</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_14">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>420</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_14">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>420</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_14">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>420</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_14">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>420</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M14</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_14">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>420</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_15">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>450</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_15">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>450</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_15">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>450</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_15">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>450</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M15</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_15">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>450</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_bt_txt_16">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>480</y>
+      <width>65</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="m_le_macro_txt_16">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>480</y>
+      <width>275</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="m_sb_macro_tmr_16">
+    <property name="geometry">
+     <rect>
+      <x>435</x>
+      <y>480</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>300000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="m_bt_macro_16">
+    <property name="geometry">
+     <rect>
+      <x>360</x>
+      <y>480</y>
+      <width>70</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>M16</string>
+    </property>
+   </widget>
+   <widget class="QCheckBox" name="m_cb_enable_macro_tmr_16">
+    <property name="geometry">
+     <rect>
+      <x>510</x>
+      <y>480</y>
+      <width>21</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -5,6 +5,7 @@
  * Copyright (c) 2015 Meinhard Ritscher <cyc1ingsir@gmail.com>
  * Copyright (c) 2015 Antoine Calando <acalando@free.fr> (improvements added to original CuteCom)
  * Copyright (c) 2017 Slawomir Pabian <sla.pab.dev@gmail.com>
+ * Copyright (c) 2018 Dimitris Tassopoulos <dimtass@gmail.com> (added macros)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -227,6 +228,34 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
 
     connect(controlPanel->m_rts_line, &QCheckBox::stateChanged, this, &MainWindow::setRTSLineState);
     connect(controlPanel->m_dtr_line, &QCheckBox::stateChanged, this, &MainWindow::setDTRLineState);
+
+    m_macroSettings = new MacroSettings(m_input_edit, this);
+    m_macroSettings->loadFile(m_settings->getCurrentSession().macroFile);
+    connect(m_macroSettings, &MacroSettings::sendCmd, this, &MainWindow::execCmd);
+    connect(m_bt_set_macros, SIGNAL(clicked(bool)), m_macroSettings, SLOT(show()));
+    connect(m_bt_macro_1, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_2, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_3, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_4, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_5, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_6, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_7, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_8, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_9, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_10, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_11, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_12, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_13, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_14, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_15, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_bt_macro_16, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
+    connect(m_macroSettings, &MacroSettings::fileChanged, m_settings,
+            [=]() {
+        m_settings->settingChanged(Settings::MacroFile, m_macroSettings->getMacroFilename());
+        m_macroSettings->loadFile(m_macroSettings->getMacroFilename());
+        qDebug() << "L1 session: " << m_settings->getCurrentSessionName() << ", fname: " << m_macroSettings->getMacroFilename()
+                 << ", sfname: " << m_settings->getCurrentSession().macroFile;
+    });
 }
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
@@ -893,6 +922,10 @@ void MainWindow::switchSession(const QString &session)
         closeDevice();
     m_settings->settingChanged(Settings::CurrentSession, session);
     controlPanel->applySessionSettings(m_settings->getCurrentSession());
+    m_macroSettings->loadFile(m_settings->getCurrentSession().macroFile);
+    qDebug() << "L2 session: " << m_settings->getCurrentSessionName()
+             << ", fname: " << m_macroSettings->getMacroFilename()
+             << ", sfname: " << m_settings->getCurrentSession().macroFile;
     m_command_history->clear();
     QStringList history = m_settings->getCurrentSession().command_history;
     if (!history.empty()) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -229,21 +229,20 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
     connect(controlPanel->m_rts_line, &QCheckBox::stateChanged, this, &MainWindow::setRTSLineState);
     connect(controlPanel->m_dtr_line, &QCheckBox::stateChanged, this, &MainWindow::setDTRLineState);
 
-    QPushButton ** macro_buttons = new QPushButton * [MacroSettings::NUM_OF_BUTTONS] {
-            m_bt_macro_1, m_bt_macro_2, m_bt_macro_3, m_bt_macro_4,
-            m_bt_macro_5, m_bt_macro_6, m_bt_macro_7, m_bt_macro_8,
-            m_bt_macro_9, m_bt_macro_10, m_bt_macro_11, m_bt_macro_12,
-            m_bt_macro_13, m_bt_macro_14, m_bt_macro_15, m_bt_macro_16,
+    QPushButton **macro_buttons = new QPushButton *[MacroSettings::NUM_OF_BUTTONS] {
+        m_bt_macro_1, m_bt_macro_2, m_bt_macro_3, m_bt_macro_4, m_bt_macro_5, m_bt_macro_6, m_bt_macro_7, m_bt_macro_8,
+            m_bt_macro_9, m_bt_macro_10, m_bt_macro_11, m_bt_macro_12, m_bt_macro_13, m_bt_macro_14, m_bt_macro_15,
+            m_bt_macro_16,
     };
     m_macroSettings = new MacroSettings(m_input_edit, macro_buttons, this);
     m_macroSettings->loadFile(m_settings->getCurrentSession().macroFile);
     connect(m_macroSettings, &MacroSettings::sendCmd, this, &MainWindow::execCmd);
     connect(m_bt_set_macros, SIGNAL(clicked(bool)), m_macroSettings, SLOT(show()));
-    connect(m_macroSettings, &MacroSettings::fileChanged, m_settings,
-            [=]() {
+    connect(m_macroSettings, &MacroSettings::fileChanged, m_settings, [=]() {
         m_settings->settingChanged(Settings::MacroFile, m_macroSettings->getMacroFilename());
         m_macroSettings->loadFile(m_macroSettings->getMacroFilename());
-        qDebug() << "L1 session: " << m_settings->getCurrentSessionName() << ", fname: " << m_macroSettings->getMacroFilename()
+        qDebug() << "L1 session: " << m_settings->getCurrentSessionName()
+                 << ", fname: " << m_macroSettings->getMacroFilename()
                  << ", sfname: " << m_settings->getCurrentSession().macroFile;
     });
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -229,26 +229,16 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
     connect(controlPanel->m_rts_line, &QCheckBox::stateChanged, this, &MainWindow::setRTSLineState);
     connect(controlPanel->m_dtr_line, &QCheckBox::stateChanged, this, &MainWindow::setDTRLineState);
 
-    m_macroSettings = new MacroSettings(m_input_edit, this);
+    QPushButton ** macro_buttons = new QPushButton * [MacroSettings::NUM_OF_BUTTONS] {
+            m_bt_macro_1, m_bt_macro_2, m_bt_macro_3, m_bt_macro_4,
+            m_bt_macro_5, m_bt_macro_6, m_bt_macro_7, m_bt_macro_8,
+            m_bt_macro_9, m_bt_macro_10, m_bt_macro_11, m_bt_macro_12,
+            m_bt_macro_13, m_bt_macro_14, m_bt_macro_15, m_bt_macro_16,
+    };
+    m_macroSettings = new MacroSettings(m_input_edit, macro_buttons, this);
     m_macroSettings->loadFile(m_settings->getCurrentSession().macroFile);
     connect(m_macroSettings, &MacroSettings::sendCmd, this, &MainWindow::execCmd);
     connect(m_bt_set_macros, SIGNAL(clicked(bool)), m_macroSettings, SLOT(show()));
-    connect(m_bt_macro_1, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_2, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_3, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_4, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_5, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_6, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_7, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_8, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_9, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_10, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_11, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_12, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_13, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_14, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_15, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
-    connect(m_bt_macro_16, SIGNAL(clicked(bool)), m_macroSettings, SLOT(macroPress()));
     connect(m_macroSettings, &MacroSettings::fileChanged, m_settings,
             [=]() {
         m_settings->settingChanged(Settings::MacroFile, m_macroSettings->getMacroFilename());

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -28,6 +28,7 @@
 #include "sessionmanager.h"
 #include "settings.h"
 #include "statusbar.h"
+#include "macrosettings.h"
 #include "ui_mainwindow.h"
 
 #include <QFont>
@@ -99,6 +100,7 @@ private:
 
     ControlPanel *controlPanel;
     SessionManager *m_sessionManager;
+    MacroSettings *m_macroSettings;
     QSerialPort *m_device;
     DeviceState m_deviceState;
     StatusBar *m_device_statusbar;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -226,6 +226,9 @@
                <height>50</height>
               </rect>
              </property>
+             <property name="toolTip">
+              <string>Open macro settings dialog</string>
+             </property>
              <property name="text">
               <string>Set Macros</string>
              </property>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>320</height>
+    <width>675</width>
+    <height>684</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -199,6 +199,250 @@
          </widget>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QGroupBox" name="m_gb_macros">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>80</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>Macros</string>
+            </property>
+            <widget class="QPushButton" name="m_bt_set_macros">
+             <property name="geometry">
+              <rect>
+               <x>5</x>
+               <y>25</y>
+               <width>81</width>
+               <height>50</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>Set Macros</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_1">
+             <property name="geometry">
+              <rect>
+               <x>90</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M1</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_2">
+             <property name="geometry">
+              <rect>
+               <x>160</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M2</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_3">
+             <property name="geometry">
+              <rect>
+               <x>230</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M3</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_4">
+             <property name="geometry">
+              <rect>
+               <x>300</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M4</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_5">
+             <property name="geometry">
+              <rect>
+               <x>370</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M5</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_6">
+             <property name="geometry">
+              <rect>
+               <x>440</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M6</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_7">
+             <property name="geometry">
+              <rect>
+               <x>510</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M7</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_8">
+             <property name="geometry">
+              <rect>
+               <x>580</x>
+               <y>25</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M8</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_9">
+             <property name="geometry">
+              <rect>
+               <x>90</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M9</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_10">
+             <property name="geometry">
+              <rect>
+               <x>160</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M10</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_11">
+             <property name="geometry">
+              <rect>
+               <x>230</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M11</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_12">
+             <property name="geometry">
+              <rect>
+               <x>300</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M12</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_13">
+             <property name="geometry">
+              <rect>
+               <x>370</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M13</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_14">
+             <property name="geometry">
+              <rect>
+               <x>440</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M14</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_15">
+             <property name="geometry">
+              <rect>
+               <x>510</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M15</string>
+             </property>
+            </widget>
+            <widget class="QPushButton" name="m_bt_macro_16">
+             <property name="geometry">
+              <rect>
+               <x>580</x>
+               <y>50</y>
+               <width>70</width>
+               <height>25</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>M16</string>
+             </property>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="m_output_layout_h">
           <property name="topMargin">
            <number>2</number>
@@ -287,8 +531,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>500</width>
-     <height>19</height>
+     <width>675</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuSessions">

--- a/settings.cpp
+++ b/settings.cpp
@@ -100,6 +100,9 @@ void Settings::settingChanged(Settings::Options option, QVariant setting)
         m_sendingStartDir = setting.toString();
         sessionSettings = false;
         break;
+    case MacroFile:
+        session.macroFile = setting.toString();
+        break;
     case CurrentSession:
         m_current_session = setting.toString();
         emit sessionChanged(getCurrentSession());
@@ -177,6 +180,7 @@ void Settings::readSessionSettings(QSettings &settings)
         session.showCtrlCharacters = settings.value("showCtrlCharacters", false).toBool();
         session.showTimestamp = settings.value("showTimestamp", false).toBool();
         session.command_history = settings.value("History").toStringList();
+        session.macroFile = settings.value("MacroFile", "").toString();
 
         m_sessions.insert(name, session);
     }
@@ -252,7 +256,6 @@ const Settings::Session Settings::getCurrentSession()
         session.flowControl = QSerialPort::NoFlowControl;
         m_sessions.insert(m_current_session, session);
     }
-
     return m_sessions.value(m_current_session);
 }
 
@@ -305,6 +308,7 @@ void Settings::saveSessionSettings()
             settings.setValue("showCtrlCharacters", session.showCtrlCharacters);
             settings.setValue("showTimestamp", session.showTimestamp);
             settings.setValue("History", session.command_history);
+            settings.setValue("MacroFile", session.macroFile);
         }
         settings.endArray();
     }

--- a/settings.h
+++ b/settings.h
@@ -48,6 +48,7 @@ public:
         CharacterDelay,
         SendStartDir,
         ProtocolOption,
+        MacroFile,
         CurrentSession
     };
 
@@ -62,6 +63,7 @@ public:
         bool showCtrlCharacters;
         bool showTimestamp;
         QStringList command_history;
+        QString macroFile;
     };
 
     enum LineTerminator { LF = 0, CR, CRLF, NONE, HEX };


### PR DESCRIPTION
One of the features I'm using a lot in br@y's terminal is the macros.
Since, I'm using also Linux a lot and CuteCom is a better solution than
running bray's terminal with wine, I've added a similar functionality in CuteCom.

I've tested on Ubuntu 18.04 and Qt 5.11.1

Dimitris