### PR TITLE
Fixed a bug in the macro plugin. Now sendCmd signal is QByteArray

### DIFF
--- a/macroplugin.cpp
+++ b/macroplugin.cpp
@@ -65,7 +65,7 @@ MacroPlugin::MacroPlugin(QFrame *parent, Settings *settings)
         //                 << ", sfname: " << m_settings->getCurrentSession().macroFile;
     });
     /* send serial string */
-    connect(m_macroSettings, SIGNAL(sendCmd(QString)), this, SIGNAL(sendCmd(QString)));
+    connect(m_macroSettings, SIGNAL(sendCmd(QByteArray)), this, SIGNAL(sendCmd(QByteArray)));
     /* unload */
     connect(ui->m_bt_unload, SIGNAL(clicked(bool)), this, SLOT(removePlugin(bool)));
 }

--- a/macroplugin.h
+++ b/macroplugin.h
@@ -44,7 +44,7 @@ public:
     int processCmd(const QString *text);
 
 signals:
-    void sendCmd(QString);
+    void sendCmd(QByteArray);
     void unload(Plugin *);
 
 public slots:

--- a/macrosettings.cpp
+++ b/macrosettings.cpp
@@ -100,7 +100,7 @@ MacroSettings::MacroSettings(QPushButton **mainButtons, QWidget *parent)
             }
         });
         /* timer events */
-        connect(m_macros[i]->tmr, &QTimer::timeout, [=]() { emit sendCmd(m_macros[i]->cmd->text()); });
+        connect(m_macros[i]->tmr, &QTimer::timeout, [=]() { emit sendCmd(m_macros[i]->cmd->text().toLatin1()); });
     }
     connect(m_bt_load_macros, &QPushButton::clicked, this, &MacroSettings::openFile);
     connect(m_bt_save_macros, &QPushButton::clicked, this, &MacroSettings::saveFile);
@@ -144,7 +144,7 @@ void MacroSettings::macroPress()
             return;
 
         /* Send macro text */
-        emit sendCmd(m_macros[idx]->cmd->text());
+        emit sendCmd(m_macros[idx]->cmd->text().toLatin1());
         TRACE << "[MacroSettings] macroPress " << m_macros[idx]->button->objectName() << " : "
               << m_macros[idx]->cmd->text();
     }

--- a/macrosettings.h
+++ b/macrosettings.h
@@ -47,7 +47,7 @@ protected slots:
 
 signals:
     void closing();
-    void sendCmd(QString);
+    void sendCmd(QByteArray);
     void fileChanged(QString);
 
 private:


### PR DESCRIPTION
Hi Meinhard,

I had a stupid bug in the macro plugin. I've changed the sendCmd signal from QString to QByteArray and now the plugin works again.