### PR TITLE
Auto reconnect feature added as an option

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -71,6 +71,10 @@ Added a plugin system
 Added macro plugin
 Added netproxy plugin
 
+Andras Biro
+Windows related fixes
+Auto reconnect feature
+
 IDEAS - still a ToDo:
 ====================================
 

--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@
 -added macros plugin to support similar to br@y's terminal
 -added netproxy plugin
 -improved logfile handling
+-added auto reconnect feature
 
 0.45.0, June 17 , 2018
 -Enable input of Crl characters using a popup or Ctrl+<x>

--- a/controlpanel.cpp
+++ b/controlpanel.cpp
@@ -50,11 +50,14 @@ ControlPanel::ControlPanel(QWidget *parent, Settings *settings)
     fillOpenModeCombo();
     m_check_lineBreak->setChecked(session.showCtrlCharacters);
     m_check_timestamp->setChecked(session.showTimestamp);
+    m_check_reconnect->setChecked(session.autoReconnect);
 
     connect(m_check_lineBreak, &QCheckBox::toggled,
             [=](bool checked) { emit settingChanged(Settings::ShowCtrlCharacters, checked); });
     connect(m_check_timestamp, &QCheckBox::toggled,
             [=](bool checked) { emit settingChanged(Settings::ShowTimestamp, checked); });
+    connect(m_check_reconnect, &QCheckBox::toggled,
+            [=](bool checked) { emit settingChanged(Settings::AutoReconnect, checked); });
     connect(this, &ControlPanel::settingChanged, settings, &Settings::settingChanged);
 
     applySessionSettings(session);
@@ -249,6 +252,7 @@ void ControlPanel::applySessionSettings(Settings::Session session)
 
     m_check_lineBreak->setChecked(session.showCtrlCharacters);
     m_check_timestamp->setChecked(session.showTimestamp);
+    m_check_reconnect->setChecked(session.autoReconnect);
 }
 
 void ControlPanel::fillDeviceCombo(const QString &deviceName)

--- a/controlpanel.ui
+++ b/controlpanel.ui
@@ -269,6 +269,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="m_check_reconnect">
+       <property name="text">
+        <string>Auto Reconnect</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -64,6 +64,7 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
     , m_keyRepeatTimer(this)
     , m_keyCode('\0')
     , m_cmdBufIndex(0)
+    , m_reconnectTimer(this)
 {
     QCoreApplication::setOrganizationName(QStringLiteral("CuteCom"));
     // setting it to CuteCom5 will prevent the original CuteCom's settings file
@@ -201,6 +202,10 @@ MainWindow::MainWindow(QWidget *parent, const QString &session)
     connect(m_command_history, &QListWidget::itemClicked, this, &MainWindow::commandFromHistoryClicked);
     connect(m_command_history, &QListWidget::doubleClicked, this, &MainWindow::execCmd);
     connect(m_bt_sendfile, &QPushButton::clicked, this, &MainWindow::sendFile);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, &MainWindow::openDevice);
+
+    m_reconnectTimer.setSingleShot(false);
+    m_reconnectTimer.setInterval(1000); //1s reconnection period is usually enough
 
     // tie the control panel's edit and this window's information label together
     m_lb_logfile->setText(m_settings->getLogFileLocation());
@@ -350,6 +355,7 @@ void MainWindow::openDevice()
     m_device->setPortName(session.device);
     m_deviceState = DEVICE_OPENING;
     if (m_device->open(session.openMode)) {
+        m_reconnectTimer.stop();
         m_deviceState = DEVICE_OPEN;
         // printDeviceInfo(); // debugging
 
@@ -389,6 +395,15 @@ void MainWindow::openDevice()
     }
 }
 
+void MainWindow::disableInput()
+{
+    m_input_edit->setEnabled(false);
+    controlPanel->m_bt_open->setFocus();
+    controlPanel->m_combo_device->setEnabled(true);
+    m_bt_sendfile->setEnabled(false);
+    m_command_history->setEnabled(false);
+}
+
 /**
  * This is connected to the control panels closing signal.
  * and need not to be called directly
@@ -399,11 +414,7 @@ void MainWindow::closeDevice()
     m_device->clearError();
     m_device->close();
     m_deviceState = DEVICE_CLOSED;
-    m_input_edit->setEnabled(false);
-    controlPanel->m_bt_open->setFocus();
-    controlPanel->m_combo_device->setEnabled(true);
-    m_bt_sendfile->setEnabled(false);
-    m_command_history->setEnabled(false);
+    disableInput();
     if (m_logFile.isOpen()) {
         m_logFile.flush();
         m_logFile.close();
@@ -420,15 +431,25 @@ void MainWindow::handleError(QSerialPort::SerialPortError error)
 {
     if (error == QSerialPort::NoError) {
         return;
-    } else if (m_deviceState == DEVICE_OPEN || m_deviceState == DEVICE_OPENING) {
+    } else if (m_deviceState == DEVICE_OPEN || m_deviceState == DEVICE_OPENING || m_deviceState == DEVICE_RECONNECT) {
         // on hot unplug of usb2serial adapters, multiple errors will be
         // reported which is of no importance to the users.
         // reporting it once should be enough
-        QString heading = (m_deviceState == DEVICE_OPENING) ? tr("Error opening device") : tr("Device Error");
-        m_deviceState = DEVICE_CLOSING;
-        QMessageBox::critical(this, heading, m_device->errorString());
-        // this will finally close the device too;
-        controlPanel->closeDevice();
+
+        if ( m_settings->getCurrentSession().autoReconnect ){
+            m_deviceState = DEVICE_RECONNECT;
+            disableInput();
+            if ( m_device->isOpen() ){ //close the device if it was opened but
+                m_device->close();
+            }
+            m_reconnectTimer.start();
+        } else {
+            QString heading = (m_deviceState == DEVICE_OPENING) ? tr("Error opening device") : tr("Device Error");
+            m_deviceState = DEVICE_CLOSING;
+            QMessageBox::critical(this, heading, m_device->errorString());
+            // this will finally close the device too;
+            controlPanel->closeDevice();
+        }
     } else if (m_deviceState != DEVICE_CLOSING && m_deviceState != DEVICE_CLOSED) {
         qDebug() << "Error-#" << error << " " << m_device->errorString();
     }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -41,7 +41,7 @@ class MainWindow : public QMainWindow, public Ui::MainWindow
 {
     Q_OBJECT
 
-    enum DeviceState { DEVICE_CLOSED, DEVICE_OPENING, DEVICE_OPEN, DEVICE_CLOSING };
+    enum DeviceState { DEVICE_CLOSED, DEVICE_OPENING, DEVICE_OPEN, DEVICE_CLOSING, DEVICE_RECONNECT };
 
 public:
     explicit MainWindow(QWidget *parent = 0, const QString &session = "");
@@ -59,6 +59,7 @@ private:
     void showAboutMsg();
     void setHexOutputFormat(bool checked);
     void saveCommandHistory();
+    void disableInput();
 
 private slots:
     /**
@@ -130,6 +131,8 @@ private:
      * @brief m_cmdBufIndex
      */
     int m_cmdBufIndex;
+
+    QTimer m_reconnectTimer;
 };
 
 #endif // MAINWINDOW_H

--- a/settings.cpp
+++ b/settings.cpp
@@ -117,6 +117,7 @@ void Settings::settingChanged(Settings::Options option, QVariant setting)
         break;
     case AutoReconnect:
         session.autoReconnect = setting.toBool();
+        emit autoConnectChanged(session.autoReconnect);
         break;
     case CurrentSession:
         m_current_session = setting.toString();

--- a/settings.cpp
+++ b/settings.cpp
@@ -115,6 +115,9 @@ void Settings::settingChanged(Settings::Options option, QVariant setting)
     case TcpLocalPort:
         session.tcpLocalPort = setting.toUInt();
         break;
+    case AutoReconnect:
+        session.autoReconnect = setting.toBool();
+        break;
     case CurrentSession:
         m_current_session = setting.toString();
         emit sessionChanged(getCurrentSession());
@@ -197,6 +200,7 @@ void Settings::readSessionSettings(QSettings &settings)
         session.udpRemoteHost = settings.value("UdpRemoteHost", "").toString();
         session.udpRemotePort = settings.value("UdpRemotePort", 7756).toUInt();
         session.tcpLocalPort = settings.value("TcpLocalPort", 7755).toUInt();
+        session.autoReconnect = settings.value("autoReconnect", false).toBool();
 
         m_sessions.insert(name, session);
     }
@@ -329,6 +333,7 @@ void Settings::saveSessionSettings()
             settings.setValue("UdpRemoteHost", session.udpRemoteHost);
             settings.setValue("UdpRemotePort", session.udpRemotePort);
             settings.setValue("TcpLocalPort", session.tcpLocalPort);
+            settings.setValue("autoReconnect", session.autoReconnect);
         }
         settings.endArray();
     }

--- a/settings.h
+++ b/settings.h
@@ -113,6 +113,7 @@ public:
 
 signals:
     void sessionChanged(const Settings::Session &);
+    void autoConnectChanged(const bool autoConnect);
 
 private:
     void readSessionSettings(QSettings &settings);

--- a/settings.h
+++ b/settings.h
@@ -53,6 +53,7 @@ public:
         UdpRemoteHost,
         UdpRemotePort,
         TcpLocalPort,
+        AutoReconnect,
         CurrentSession
     };
 
@@ -72,6 +73,7 @@ public:
         QString udpRemoteHost;
         quint16 udpRemotePort;
         quint16 tcpLocalPort;
+        bool autoReconnect;
     };
 
     enum LineTerminator { LF = 0, CR, CRLF, NONE, HEX };


### PR DESCRIPTION
I've added auto reconnect capabilites to cutecom, similar to what teraterm has. This is useful for USB serial converters, e.g. if you have no other method of resetting a device then unplugging the USB.
Demo:
https://www.dropbox.com/s/2puh3pgmfm7loxd/cutecom_reconnect.mp4?dl=0